### PR TITLE
Fixing issue under g++-9 where noexcept was not specified correctly

### DIFF
--- a/src/datatypes/CircularArray.h
+++ b/src/datatypes/CircularArray.h
@@ -151,8 +151,7 @@ class CircularArray {
   /* @brief Copy constructor
    * @param[in] arr The array to copy
    */
-  constexpr CircularArray(const CircularArray<T, array_size> &arr) noexcept =
-      default;
+  constexpr CircularArray(const CircularArray<T, array_size> &arr) = default;
 
   /* @brief Equality operator */
   constexpr bool operator==(const CircularArray<T, array_size> &b) const {


### PR DESCRIPTION
# Issue
Older versions of g++ (specifically g++-9) did not allow the `CircularArray` copy constructor to be specified `noexcept`.

Thanks @mattbilskie for locating this issue