### PR TITLE
Modernizing Codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,6 @@
 cmake_minimum_required(VERSION 3.18)
 project(gahm CXX)
 
-
 # Warnings, Sanitizers, etc
 add_library(project_options INTERFACE)
 add_library(project_warnings INTERFACE)
@@ -35,10 +34,11 @@ mark_as_advanced(CLEAR CMAKE_CXX_FLAGS)
 mark_as_advanced(CLEAR CMAKE_CXX_FLAGS_RELEASE)
 mark_as_advanced(CLEAR CMAKE_CXX_FLAGS_DEBUG)
 
-option(BUILD_SHARED_LIBS "Enable compilation of shared libraries" OFF)
 option(GAHM_ENABLE_WARNINGS "Enable verbose compiler warnings" OFF)
 option(GAHM_ENABLE_COVERAGE "Enable code coverage" OFF)
-option(GAHM_DEBUG "Enable debug mode" ON)
+
+option(GAHM_ENABLE_SHARED "Enable compilation of shared GAHM library" ON)
+option(GAHM_ENABLE_STATIC "Enable compilation of static GAHM library" OFF)
 
 # ##############################################################################
 # C++ Checks

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,8 @@ setuptools.setup(
                 "-DPython3_ROOT_DIR={:s}".format(str(Path(sys.prefix).resolve())),
                 "-DGAHM_ENABLE_PYTHON:BOOL=ON",
                 "-DPYTHON_PACKAGE_BUILD:BOOL=ON",
+                "-DGAHM_ENABLE_SHARED:BOOL=OFF",
+                "-DGAHM_ENABLE_STATIC:BOOL=OFF",
             ]
             + CIBW_CMAKE_OPTIONS,
         ),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,13 +66,7 @@ if(BUILD_SHARED_LIBS)
   target_link_libraries(gahm_shared PUBLIC gahm_interface)
 endif()
 
-# ...If we detected that the system did not have std::uncaught_exceptions, then
-# define HAS_UNCAUGHT_EXCEPTIONS to 0 otherwise leave it undefined. This is an
-# oddity of C++17 on MacOS. We're doing this because it is in Howard Hinant's
-# date library, and we don't want to force C++20 onto users
-if(NOT HAVE_STD_UNCAUGHT_EXCEPTIONS)
-  target_compile_definitions(gahm_objectlib PRIVATE HAS_UNCAUGHT_EXCEPTIONS=0)
-endif()
+target_compile_definitions(gahm_objectlib PRIVATE HAS_UNCAUGHT_EXCEPTIONS=0)
 
 target_include_directories(
   gahm_objectlib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,9 +38,7 @@ set(SOURCES
     physical/Earth.h
     physical/Units.h
     util/Interpolation.h
-    util/StringUtilities.h
-)
-
+    util/StringUtilities.h)
 
 # ##############################################################################
 
@@ -48,34 +46,52 @@ set(SOURCES
 # Fortran
 # ##############################################################################
 if(GAHM_ENABLE_FORTRAN)
-  list(APPEND SOURCES fortran/gahm_fortran.cpp fortran/gahm.F90)
   set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/fortran)
+  add_library(
+    gahm_fortran OBJECT ${CMAKE_CURRENT_SOURCE_DIR}/fortran/gahm.F90
+                        ${CMAKE_CURRENT_SOURCE_DIR}/fortran/gahm_fortran.cpp)
+  target_include_directories(gahm_fortran PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 # ##############################################################################
 
 add_library(gahm_interface INTERFACE)
 add_library(gahm_objectlib OBJECT ${SOURCES})
 
-add_library(gahm_static STATIC $<TARGET_OBJECTS:gahm_objectlib>)
-set_target_properties(gahm_static PROPERTIES OUTPUT_NAME gahm)
-target_link_libraries(gahm_static PUBLIC gahm_interface)
+if(GAHM_ENABLE_STATIC)
+  add_library(gahm_static STATIC $<TARGET_OBJECTS:gahm_objectlib>)
+  set_target_properties(gahm_static PROPERTIES OUTPUT_NAME gahm)
+  target_link_libraries(gahm_static PUBLIC gahm_interface)
+  if(GAHM_ENABLE_FORTRAN)
+    target_link_libraries(gahm_static PRIVATE gahm_fortran)
+  endif()
+endif()
 
-if(BUILD_SHARED_LIBS)
+if(GAHM_ENABLE_SHARED)
   add_library(gahm_shared SHARED $<TARGET_OBJECTS:gahm_objectlib>)
   set_target_properties(gahm_shared PROPERTIES OUTPUT_NAME gahm)
   target_link_libraries(gahm_shared PUBLIC gahm_interface)
+  if(GAHM_ENABLE_FORTRAN)
+    target_link_libraries(gahm_shared PRIVATE gahm_fortran)
+  endif()
 endif()
 
-target_compile_definitions(gahm_objectlib PRIVATE HAS_UNCAUGHT_EXCEPTIONS=0)
+# ...If we detected that the system did not have std::uncaught_exceptions, then
+# define HAS_UNCAUGHT_EXCEPTIONS to 0 otherwise leave it undefined. This is an
+# oddity of C++17 on MacOS. We're doing this because it is in Howard Hinant's
+# date library, and we don't want to force C++20 onto users
+if(NOT GAHM_HAS_UNCAUGHT_EXCEPTIONS)
+  target_compile_definitions(gahm_objectlib PRIVATE HAS_UNCAUGHT_EXCEPTIONS=0)
+endif()
 
+target_include_directories(gahm_objectlib PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(
-  gahm_objectlib
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS}
+  gahm_objectlib SYSTEM
+  PRIVATE ${Boost_INCLUDE_DIRS}
           ${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/date_hh
           ${CMAKE_CURRENT_SOURCE_DIR}/../thirdparty/fmt-9.1.0/include)
 
 if(GAHM_ENABLE_WARNINGS)
-  target_link_libraries(gahm_objectlib INTERFACE project_warnings)
+  target_link_libraries(gahm_objectlib PRIVATE project_warnings)
 endif()
 
 target_link_libraries(gahm_interface INTERFACE project_options)
@@ -89,10 +105,12 @@ if(GAHM_ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   set_target_properties(
     gahm_objectlib PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
                               LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
-  set_target_properties(
-    gahm_static PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
-                           LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
-  if(BUILD_SHARED_LIBS)
+  if(GAHM_ENABLE_STATIC)
+    set_target_properties(
+      gahm_static PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
+                             LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
+  endif()
+  if(GAHM_ENABLE_SHARED)
     set_target_properties(
       gahm_shared PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
                              LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
@@ -104,18 +122,21 @@ endif()
 # ##############################################################################
 # Install
 # ##############################################################################
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        FILES_MATCHING PATTERN "*.h"
-        PATTERN "*Private.h" EXCLUDE
-)
+if(GAHM_ENABLE_STATIC)
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "*Private.h" EXCLUDE)
 install(
   TARGETS gahm_static
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin)
+endif()
 
-if(BUILD_SHARED_LIBS)
+if(GAHM_ENABLE_SHARED)
   install(
     TARGETS gahm_shared
     LIBRARY DESTINATION lib

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,17 +2,46 @@
 # GAHM library
 # ##############################################################################
 set(SOURCES
+    datatypes/Date.h
     datatypes/Date.cpp
+    datatypes/Point.h
+    datatypes/PointCloud.h
+    datatypes/PointPosition.h
+    datatypes/Uvp.h
+    datatypes/VortexSolution.h
+    datatypes/WindGrid.h
+    atcf/AtcfFile.h
+    atcf/AtcfSnap.h
+    atcf/AtcfIsotach.h
+    atcf/AtcfQuadrant.h
+    atcf/StormPosition.h
+    atcf/StormTranslation.h
     atcf/AtcfSnap.cpp
     atcf/AtcfFile.cpp
+    preprocessor/Preprocessor.h
     preprocessor/Preprocessor.cpp
+    gahm/GahmEquations.h
+    gahm/GahmRadiusSolver.h
+    gahm/GahmSolver.h
+    gahm/GahmRadiusSolverPrivate.h
     gahm/GahmEquations.cpp
     gahm/GahmRadiusSolver.cpp
     gahm/GahmSolver.cpp
     gahm/GahmRadiusSolverPrivate.cpp
+    vortex/Vortex.h
     vortex/Vortex.cpp
-    vortex/Vortex.cpp
-    output/OwiOutput.cpp)
+    output/OwiOutput.cpp
+    output/OutputFile.h
+    output/OwiOutput.h
+    physical/Atmospheric.h
+    physical/Constants.h
+    physical/Earth.h
+    physical/Units.h
+    util/Interpolation.h
+    util/StringUtilities.h
+)
+
+
 # ##############################################################################
 
 # ##############################################################################
@@ -28,14 +57,16 @@ add_library(gahm_interface INTERFACE)
 add_library(gahm_objectlib OBJECT ${SOURCES})
 
 add_library(gahm_static STATIC $<TARGET_OBJECTS:gahm_objectlib>)
+set_target_properties(gahm_static PROPERTIES OUTPUT_NAME gahm)
 target_link_libraries(gahm_static PUBLIC gahm_interface)
 
 if(BUILD_SHARED_LIBS)
-    add_library(gahm SHARED $<TARGET_OBJECTS:gahm_objectlib>)
-    target_link_libraries(gahm PUBLIC gahm_interface)
+  add_library(gahm_shared SHARED $<TARGET_OBJECTS:gahm_objectlib>)
+  set_target_properties(gahm_shared PROPERTIES OUTPUT_NAME gahm)
+  target_link_libraries(gahm_shared PUBLIC gahm_interface)
 endif()
 
-#...If we detected that the system did not have std::uncaught_exceptions, then
+# ...If we detected that the system did not have std::uncaught_exceptions, then
 # define HAS_UNCAUGHT_EXCEPTIONS to 0 otherwise leave it undefined. This is an
 # oddity of C++17 on MacOS. We're doing this because it is in Howard Hinant's
 # date library, and we don't want to force C++20 onto users
@@ -69,11 +100,33 @@ if(GAHM_ENABLE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU")
                            LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
   if(BUILD_SHARED_LIBS)
     set_target_properties(
-      gahm PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
-                  LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
+      gahm_shared PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
+                             LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
   endif()
 elseif(GAHM_ENABLE_COVERAGE)
   message(WARNING "Coverage is only supported with GCC")
+endif()
+
+# ##############################################################################
+# Install
+# ##############################################################################
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING PATTERN "*.h"
+        PATTERN "*Private.h" EXCLUDE
+)
+install(
+  TARGETS gahm_static
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)
+
+if(BUILD_SHARED_LIBS)
+  install(
+    TARGETS gahm_shared
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin)
 endif()
 
 # ##############################################################################

--- a/src/atcf/AtcfFile.h
+++ b/src/atcf/AtcfFile.h
@@ -22,10 +22,12 @@
 #define GAHM_SRC_ATCF_ATCFFILE_H_
 
 #include <algorithm>
+#include <cstddef>
 #include <string>
 #include <vector>
 
 #include "atcf/AtcfSnap.h"
+#include "datatypes/Date.h"
 
 #ifdef SWIG
 #define NODISCARD
@@ -43,28 +45,35 @@ class AtcfFile {
 
   void read();
 
-  NODISCARD size_t size() const;
+  NODISCARD auto size() const -> size_t;
 
   std::vector<Gahm::Atcf::AtcfSnap>& data() { return m_atcfSnaps; }
 
-  NODISCARD const std::vector<Gahm::Atcf::AtcfSnap>& data() const {
+#ifndef SWIG
+  NODISCARD auto data() const -> const std::vector<Gahm::Atcf::AtcfSnap>& {
     return m_atcfSnaps;
   }
+#endif
 
-  NODISCARD bool empty() const { return m_atcfSnaps.empty(); }
+  NODISCARD auto empty() const -> bool { return m_atcfSnaps.empty(); }
 
-  NODISCARD Atcf::AtcfSnap& at(size_t index) { return m_atcfSnaps.at(index); }
-  NODISCARD const Atcf::AtcfSnap& at(size_t index) const {
+  NODISCARD auto at(size_t index) -> Atcf::AtcfSnap& {
+    return m_atcfSnaps.at(index);
+  }
+#ifndef SWIG
+  NODISCARD auto at(size_t index) const -> const Atcf::AtcfSnap& {
     return m_atcfSnaps.at(index);
   }
 
-#ifndef SWIG
+  NODISCARD auto front() -> Atcf::AtcfSnap& { return m_atcfSnaps.front(); }
+  NODISCARD auto front() const -> const Atcf::AtcfSnap& {
+    return m_atcfSnaps.front();
+  }
 
-  NODISCARD Atcf::AtcfSnap& front() { return m_atcfSnaps.front(); }
-  NODISCARD const Atcf::AtcfSnap& front() const { return m_atcfSnaps.front(); }
-
-  NODISCARD Atcf::AtcfSnap& back() { return m_atcfSnaps.back(); }
-  NODISCARD const Atcf::AtcfSnap& back() const { return m_atcfSnaps.back(); }
+  NODISCARD auto back() -> Atcf::AtcfSnap& { return m_atcfSnaps.back(); }
+  NODISCARD auto back() const -> const Atcf::AtcfSnap& {
+    return m_atcfSnaps.back();
+  }
 
   //...Iterators
   NODISCARD auto begin() { return m_atcfSnaps.begin(); }
@@ -82,21 +91,23 @@ class AtcfFile {
   }
 
   //...Indexing
-  Gahm::Atcf::AtcfSnap& operator[](size_t index) { return m_atcfSnaps[index]; }
-  const Gahm::Atcf::AtcfSnap& operator[](size_t index) const {
+  auto operator[](size_t index) -> Gahm::Atcf::AtcfSnap& {
+    return m_atcfSnaps[index];
+  }
+  auto operator[](size_t index) const -> const Gahm::Atcf::AtcfSnap& {
     return m_atcfSnaps[index];
   }
 #endif
 
   void write(const std::string& filename);
 
-  NODISCARD std::string filename() const { return m_filename; }
+  NODISCARD auto filename() const -> std::string { return m_filename; }
 
   void addAtcfSnap(const Gahm::Atcf::AtcfSnap& snap);
 
  private:
   std::string m_filename;
-  bool m_quiet;
+  bool m_quiet{false};
   std::vector<Gahm::Atcf::AtcfSnap> m_atcfSnaps;
 };
 

--- a/src/atcf/AtcfFile.h
+++ b/src/atcf/AtcfFile.h
@@ -57,7 +57,7 @@ class AtcfFile {
 
   NODISCARD auto empty() const -> bool { return m_atcfSnaps.empty(); }
 
-  NODISCARD auto at(size_t index) -> Atcf::AtcfSnap& {
+  NODISCARD Atcf::AtcfSnap& at(size_t index) {
     return m_atcfSnaps.at(index);
   }
 #ifndef SWIG

--- a/src/atcf/AtcfIsotach.h
+++ b/src/atcf/AtcfIsotach.h
@@ -21,6 +21,7 @@
 #ifndef GAHM_SRC_ATCF_ATCFISOTACH_H_
 #define GAHM_SRC_ATCF_ATCFISOTACH_H_
 
+#include <array>
 #include <cassert>
 
 #include "atcf/AtcfQuadrant.h"
@@ -43,10 +44,10 @@ class AtcfIsotach {
         m_quadrants({AtcfQuadrant(0, radii[0]), AtcfQuadrant(1, radii[1]),
                      AtcfQuadrant(2, radii[2]), AtcfQuadrant(3, radii[3])}) {}
 
-  NODISCARD double getWindSpeed() const { return m_wind_speed; }
+  NODISCARD auto getWindSpeed() const -> double { return m_wind_speed; }
 
-  NODISCARD const Gahm::Datatypes::CircularArray<Gahm::Atcf::AtcfQuadrant, 4>
-      &getQuadrants() const {
+  NODISCARD const Gahm::Datatypes::CircularArray<Gahm::Atcf::AtcfQuadrant, 4> &
+  getQuadrants() const {
     return m_quadrants;
   }
 
@@ -63,7 +64,7 @@ class AtcfIsotach {
     return m_quadrants[quadrant_index];
   }
 
-  NODISCARD Gahm::Datatypes::CircularArray<double, 4> radii() const {
+  NODISCARD auto radii() const -> Gahm::Datatypes::CircularArray<double, 4> {
     Gahm::Datatypes::CircularArray<double, 4> r{};
     for (int i = 0; i < 4; ++i) {
       r[i] = m_quadrants[i].getIsotachRadius();

--- a/src/atcf/AtcfQuadrant.h
+++ b/src/atcf/AtcfQuadrant.h
@@ -21,6 +21,8 @@
 #ifndef GAHM_SRC_ATCF_ATCFQUADRANT_H_
 #define GAHM_SRC_ATCF_ATCFQUADRANT_H_
 
+#include <ostream>
+
 #include "datatypes/CircularArray.h"
 #include "physical/Constants.h"
 
@@ -45,17 +47,17 @@ class AtcfQuadrant {
         m_isotach_speed_at_boundary_layer(isotach_speed_at_boundary_layer),
         m_vmax_at_boundary_layer(vmax_at_boundary_layer) {}
 
-  NODISCARD double getIsotachRadius() const { return m_isotach_radius; }
-  NODISCARD double getRadiusToMaxWindSpeed() const {
+  NODISCARD auto getIsotachRadius() const -> double { return m_isotach_radius; }
+  NODISCARD auto getRadiusToMaxWindSpeed() const -> double {
     return m_radius_to_max_wind_speed;
   }
-  NODISCARD double getGahmHollandB() const { return m_gahm_holland_b; }
-  NODISCARD double getIsotachSpeedAtBoundaryLayer() const {
+  NODISCARD auto getGahmHollandB() const -> double { return m_gahm_holland_b; }
+  NODISCARD auto getIsotachSpeedAtBoundaryLayer() const -> double {
     return m_isotach_speed_at_boundary_layer;
   }
-  NODISCARD int getQuadrantIndex() const { return m_quadrant_index; }
+  NODISCARD auto getQuadrantIndex() const -> int { return m_quadrant_index; }
 
-  NODISCARD double getVmaxAtBoundaryLayer() const {
+  NODISCARD auto getVmaxAtBoundaryLayer() const -> double {
     return m_vmax_at_boundary_layer;
   }
 
@@ -102,12 +104,11 @@ class AtcfQuadrant {
 }  // namespace Gahm::Atcf
 
 #ifndef SWIG
-static std::ostream &operator<<(std::ostream &os,
-                                const Gahm::Atcf::AtcfQuadrant &q) {
+static auto operator<<(std::ostream &os, const Gahm::Atcf::AtcfQuadrant &q)
+    -> std::ostream & {
   os << "[Quadrant]: " << q.getQuadrantIndex() << std::endl;
   os << "   Isotach Radius: " << q.getIsotachRadius() << std::endl;
-  os << "   Radius to Max Wind Speed: " << q.getRadiusToMaxWindSpeed()
-     << std::endl;
+  os << "   Radius to Max Wind Speed: " << q.getRadiusToMaxWindSpeed() << '\n';
   os << "   GAHM Holland B: " << q.getGahmHollandB() << std::endl;
   os << "   Isotach Speed at Boundary Layer: "
      << q.getIsotachSpeedAtBoundaryLayer() << std::endl;

--- a/src/atcf/AtcfSnap.cpp
+++ b/src/atcf/AtcfSnap.cpp
@@ -24,7 +24,6 @@
 #include <utility>
 
 #include "fmt/compile.h"
-#include "fmt/core.h"
 #include "physical/Atmospheric.h"
 #include "physical/Units.h"
 #include "util/StringUtilities.h"

--- a/src/atcf/AtcfSnap.cpp
+++ b/src/atcf/AtcfSnap.cpp
@@ -20,11 +20,23 @@
 //
 #include "AtcfSnap.h"
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "AtcfIsotach.h"
+#include "StormPosition.h"
+#include "StormTranslation.h"
+#include "boost/algorithm/string/trim.hpp"
+#include "datatypes/CircularArray.h"
+#include "datatypes/Date.h"
 #include "fmt/compile.h"
 #include "physical/Atmospheric.h"
+#include "physical/Constants.h"
 #include "physical/Units.h"
 #include "util/StringUtilities.h"
 
@@ -56,17 +68,17 @@ AtcfSnap::AtcfSnap(AtcfSnap::BASIN basin, double central_pressure,
       m_date(date),
       m_storm_id(storm_id),
       m_basin(basin),
-      m_storm_name(std::move(storm_name)),
-      m_radii(std::array<std::vector<double>, 4>{}),
       m_position(0.0, 0.0),
-      m_translation(0.0, 0.0) {}
+      m_translation(0.0, 0.0),
+      m_storm_name(std::move(storm_name)),
+      m_radii(std::array<std::vector<double>, 4>{}) {}
 
 /*
  * Converts a string to a basin enum
  * @param basin String representation of the basin
  * @return Basin enum
  */
-AtcfSnap::BASIN AtcfSnap::basinFromString(const std::string& basin) {
+auto AtcfSnap::basinFromString(const std::string& basin) -> AtcfSnap::BASIN {
   if (basin == "WP") {
     return AtcfSnap::BASIN::WP;
   } else if (basin == "IO") {
@@ -91,7 +103,7 @@ AtcfSnap::BASIN AtcfSnap::basinFromString(const std::string& basin) {
  * @param basin Basin enum
  * @return String representation of the basin
  */
-std::string AtcfSnap::basinToString(AtcfSnap::BASIN basin) {
+auto AtcfSnap::basinToString(AtcfSnap::BASIN basin) -> std::string {
   switch (basin) {
     case AtcfSnap::BASIN::WP:
       return "WP";
@@ -116,7 +128,7 @@ std::string AtcfSnap::basinToString(AtcfSnap::BASIN basin) {
  * Returns the central pressure of the storm
  * @return Central pressure of the storm
  */
-double AtcfSnap::centralPressure() const { return m_central_pressure; }
+auto AtcfSnap::centralPressure() const -> double { return m_central_pressure; }
 
 /*
  * Sets the central pressure of the storm
@@ -130,7 +142,9 @@ void AtcfSnap::setCentralPressure(double centralPressure) {
  * Returns the background pressure of the storm
  * @return Background pressure of the storm
  */
-double AtcfSnap::backgroundPressure() const { return m_background_pressure; }
+auto AtcfSnap::backgroundPressure() const -> double {
+  return m_background_pressure;
+}
 
 /*
  * Sets the background pressure of the storm
@@ -144,7 +158,9 @@ void AtcfSnap::setBackgroundPressure(double backgroundPressure) {
  * Returns the radius to maximum winds of the storm
  * @return Radius to maximum winds of the storm
  */
-double AtcfSnap::radiusToMaxWinds() const { return m_radius_to_max_winds; }
+auto AtcfSnap::radiusToMaxWinds() const -> double {
+  return m_radius_to_max_winds;
+}
 
 /*
  * Sets the radius to maximum winds of the storm
@@ -158,7 +174,7 @@ void AtcfSnap::setRadiusToMaxWinds(double radiusToMaxWinds) {
  * Returns the maximum sustained wind speed of the storm
  * @return Maximum sustained wind speed of the storm
  */
-double AtcfSnap::vmax() const { return m_vmax; }
+auto AtcfSnap::vmax() const -> double { return m_vmax; }
 
 /*
  * Sets the maximum sustained wind speed of the storm
@@ -170,7 +186,9 @@ void AtcfSnap::setVmax(double vmax) { m_vmax = vmax; }
  * Returns the maximum sustained wind speed of the storm in the boundary layer
  * @return Maximum sustained wind speed of the storm in the boundary layer
  */
-double AtcfSnap::vmaxBoundaryLayer() const { return m_vmax_boundary_layer; }
+auto AtcfSnap::vmaxBoundaryLayer() const -> double {
+  return m_vmax_boundary_layer;
+}
 
 /*
  * Sets the maximum sustained wind speed of the storm in the boundary layer
@@ -197,7 +215,7 @@ void AtcfSnap::setDate(const Gahm::Datatypes::Date& date) { m_date = date; }
  * Returns the storm ID
  * @return Storm ID
  */
-int AtcfSnap::stormId() const { return m_storm_id; }
+auto AtcfSnap::stormId() const -> int { return m_storm_id; }
 
 /*
  * Sets the storm ID
@@ -209,7 +227,7 @@ void AtcfSnap::setStormId(int stormId) { m_storm_id = stormId; }
  * Returns the basin enum of the storm
  * @return Basin enum of the storm
  */
-AtcfSnap::BASIN AtcfSnap::basin() const { return m_basin; }
+auto AtcfSnap::basin() const -> AtcfSnap::BASIN { return m_basin; }
 
 /*
  * Sets the basin enum of the storm
@@ -221,7 +239,7 @@ void AtcfSnap::setBasin(AtcfSnap::BASIN basin) { m_basin = basin; }
  * Returns the storm name
  * @return Storm name
  */
-const std::string& AtcfSnap::stormName() const { return m_storm_name; }
+auto AtcfSnap::stormName() const -> const std::string& { return m_storm_name; }
 
 /*
  * Sets the storm name
@@ -235,7 +253,7 @@ void AtcfSnap::setStormName(const std::string& stormName) {
  * Returns the isotachs of the storm
  * @return Isotachs of the storm
  */
-const std::vector<AtcfIsotach>& AtcfSnap::getIsotachs() const {
+auto AtcfSnap::getIsotachs() const -> const std::vector<AtcfIsotach>& {
   return m_isotachs;
 }
 
@@ -243,7 +261,7 @@ const std::vector<AtcfIsotach>& AtcfSnap::getIsotachs() const {
  * Returns the Holland B of the storm
  * @return Holland B of the storm
  */
-double AtcfSnap::hollandB() const { return m_holland_b; }
+auto AtcfSnap::hollandB() const -> double { return m_holland_b; }
 
 /**
  * Sets the radius of the storm
@@ -255,14 +273,14 @@ void AtcfSnap::setHollandB(double hollandB) { m_holland_b = hollandB; }
  * Returns the isotachs of the snap
  * @return Isotachs of the snap
  */
-std::vector<AtcfIsotach>& AtcfSnap::getIsotachs() { return m_isotachs; }
+auto AtcfSnap::getIsotachs() -> std::vector<AtcfIsotach>& { return m_isotachs; }
 
 /*
  * Returns the radii of the storm in the form of a circular array
  * @return Radii of the storm in the form of a circular array
  */
-const Gahm::Datatypes::CircularArray<std::vector<double>, 4>& AtcfSnap::radii()
-    const {
+auto AtcfSnap::radii() const
+    -> const Gahm::Datatypes::CircularArray<std::vector<double>, 4>& {
   return m_radii;
 }
 
@@ -270,7 +288,7 @@ const Gahm::Datatypes::CircularArray<std::vector<double>, 4>& AtcfSnap::radii()
  * Returns the number of isotachs in the snap
  * @return Number of isotachs in the snap
  */
-size_t AtcfSnap::numberOfIsotachs() const { return m_isotachs.size(); }
+auto AtcfSnap::numberOfIsotachs() const -> size_t { return m_isotachs.size(); }
 
 /*
  * Adds an isotach to the snap
@@ -286,7 +304,8 @@ void AtcfSnap::addIsotach(const AtcfIsotach& isotach) {
  * @param line Line to parse
  * @return ATCF snap
  */
-std::optional<AtcfSnap> AtcfSnap::parseAtcfSnap(const std::string& line) {
+auto AtcfSnap::parseAtcfSnap(const std::string& line)
+    -> std::optional<AtcfSnap> {
   constexpr double kt2ms = Gahm::Physical::Units::convert(
       Gahm::Physical::Units::Knot, Gahm::Physical::Units::MetersPerSecond);
   constexpr double nmi2m = Gahm::Physical::Units::convert(
@@ -337,7 +356,8 @@ std::optional<AtcfSnap> AtcfSnap::parseAtcfSnap(const std::string& line) {
  * @param tokens Tokens to parse
  * @return Isotach parsed from the tokens
  */
-AtcfIsotach AtcfSnap::parseIsotach(const std::vector<std::string>& tokens) {
+auto AtcfSnap::parseIsotach(const std::vector<std::string>& tokens)
+    -> AtcfIsotach {
   using namespace Gahm::detail::Utilities;
   constexpr double kt2ms = Gahm::Physical::Units::convert(
       Gahm::Physical::Units::Knot, Gahm::Physical::Units::MetersPerSecond);
@@ -368,8 +388,8 @@ AtcfIsotach AtcfSnap::parseIsotach(const std::vector<std::string>& tokens) {
  * @param tau_str Time string
  * @return Date
  */
-Gahm::Datatypes::Date AtcfSnap::parseDate(const std::string& date_str,
-                                          const std::string& tau_str) {
+auto AtcfSnap::parseDate(const std::string& date_str,
+                         const std::string& tau_str) -> Gahm::Datatypes::Date {
   auto base_date =
       Gahm::Datatypes::Date::fromString(boost::trim_copy(date_str), "%Y%m%d%H");
   const auto tau = Gahm::detail::Utilities::readValueCheckBlank<int>(tau_str);
@@ -382,7 +402,7 @@ Gahm::Datatypes::Date AtcfSnap::parseDate(const std::string& date_str,
  * @param other Other atcf snap
  * @return True if this atcf snap is before the other atcf snap
  */
-bool AtcfSnap::operator<(const AtcfSnap& other) const {
+auto AtcfSnap::operator<(const AtcfSnap& other) const -> bool {
   return m_date < other.m_date;
 }
 
@@ -390,7 +410,7 @@ bool AtcfSnap::operator<(const AtcfSnap& other) const {
  * Returns the current position of the storm
  * @return Current position of the storm
  */
-const StormPosition& AtcfSnap::position() const { return m_position; }
+auto AtcfSnap::position() const -> const StormPosition& { return m_position; }
 
 /*
  * Sets the current position of the storm
@@ -403,7 +423,7 @@ void AtcfSnap::setPosition(const StormPosition& position) {
 /*
  * Returns if the snap has a valid set of data
  */
-bool AtcfSnap::isValid() const {
+auto AtcfSnap::isValid() const -> bool {
   if (m_isotachs.empty()) {
     return false;
   }
@@ -425,7 +445,9 @@ bool AtcfSnap::isValid() const {
  * Returns the storm translation for the snap
  * @return Storm translation for the snap
  */
-const StormTranslation& AtcfSnap::translation() const { return m_translation; }
+auto AtcfSnap::translation() const -> const StormTranslation& {
+  return m_translation;
+}
 
 /*
  * Sets the storm translation for the snap
@@ -438,9 +460,8 @@ void AtcfSnap::setTranslation(const StormTranslation& translation) {
 /*
  * Returns a string representation of the snap in GAHM format
  */
-std::string AtcfSnap::to_string(size_t cycle,
-                                const Gahm::Datatypes::Date& start_date,
-                                size_t isotach_index) const {
+auto AtcfSnap::to_string(size_t cycle, const Gahm::Datatypes::Date& start_date,
+                         size_t isotach_index) const -> std::string {
   constexpr double ms2kt = Gahm::Physical::Units::convert(
       Gahm::Physical::Units::MetersPerSecond, Gahm::Physical::Units::Knot);
   constexpr double m2nmi = Gahm::Physical::Units::convert(

--- a/src/atcf/AtcfSnap.h
+++ b/src/atcf/AtcfSnap.h
@@ -21,7 +21,10 @@
 #ifndef GAHM_SRC_ATCFSNAP_H_
 #define GAHM_SRC_ATCFSNAP_H_
 
+#include <cstddef>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "atcf/AtcfIsotach.h"
 #include "atcf/StormPosition.h"
@@ -52,44 +55,48 @@ class AtcfSnap {
            const Gahm::Datatypes::Date& date, int storm_id,
            std::string storm_name);
 
-  static std::optional<AtcfSnap> parseAtcfSnap(const std::string& line);
+  static auto parseAtcfSnap(const std::string& line) -> std::optional<AtcfSnap>;
 
-  NODISCARD double centralPressure() const;
+  NODISCARD auto centralPressure() const -> double;
   void setCentralPressure(double centralPressure);
 
-  NODISCARD double backgroundPressure() const;
+  NODISCARD auto backgroundPressure() const -> double;
   void setBackgroundPressure(double backgroundPressure);
 
-  NODISCARD double radiusToMaxWinds() const;
+  NODISCARD auto radiusToMaxWinds() const -> double;
   void setRadiusToMaxWinds(double radiusToMaxWinds);
 
-  NODISCARD double vmax() const;
+  NODISCARD auto vmax() const -> double;
   void setVmax(double vmax);
 
-  NODISCARD double vmaxBoundaryLayer() const;
+  NODISCARD auto vmaxBoundaryLayer() const -> double;
   void setVmaxBoundaryLayer(double vmaxBoundaryLayer);
 
   NODISCARD const Gahm::Datatypes::Date& date() const;
   void setDate(const Gahm::Datatypes::Date& date);
 
-  NODISCARD int stormId() const;
+  NODISCARD auto stormId() const -> int;
   void setStormId(int stormId);
 
-  NODISCARD Gahm::Atcf::AtcfSnap::BASIN basin() const;
+  NODISCARD auto basin() const -> Gahm::Atcf::AtcfSnap::BASIN;
   void setBasin(Gahm::Atcf::AtcfSnap::BASIN basin);
 
   NODISCARD const std::string& stormName() const;
   void setStormName(const std::string& stormName);
 
-  NODISCARD const std::vector<Gahm::Atcf::AtcfIsotach>& getIsotachs() const;
-  std::vector<Gahm::Atcf::AtcfIsotach>& getIsotachs();
+#ifndef SWIG
+  NODISCARD auto getIsotachs() const
+      -> const std::vector<Gahm::Atcf::AtcfIsotach>&;
+#endif
+  auto getIsotachs() -> std::vector<Gahm::Atcf::AtcfIsotach>&;
 
-  NODISCARD static Gahm::Atcf::AtcfSnap::BASIN basinFromString(
-      const std::string& basin);
+  NODISCARD static auto basinFromString(const std::string& basin)
+      -> Gahm::Atcf::AtcfSnap::BASIN;
 
-  NODISCARD static std::string basinToString(Gahm::Atcf::AtcfSnap::BASIN basin);
+  NODISCARD static auto basinToString(Gahm::Atcf::AtcfSnap::BASIN basin)
+      -> std::string;
 
-  NODISCARD size_t numberOfIsotachs() const;
+  NODISCARD auto numberOfIsotachs() const -> size_t;
 
   NODISCARD const Gahm::Atcf::StormPosition& position() const;
   void setPosition(const Gahm::Atcf::StormPosition& position);
@@ -97,18 +104,18 @@ class AtcfSnap {
   NODISCARD const Gahm::Atcf::StormTranslation& translation() const;
   void setTranslation(const Gahm::Atcf::StormTranslation& translation);
 
-  NODISCARD double hollandB() const;
+  NODISCARD auto hollandB() const -> double;
   void setHollandB(double hollandB);
 
   void addIsotach(const Gahm::Atcf::AtcfIsotach& isotach);
 
-  bool operator<(const Gahm::Atcf::AtcfSnap& other) const;
+  auto operator<(const Gahm::Atcf::AtcfSnap& other) const -> bool;
 
-  NODISCARD bool isValid() const;
+  NODISCARD auto isValid() const -> bool;
 
-  NODISCARD std::string to_string(size_t cycle,
-                                  const Gahm::Datatypes::Date& start_date,
-                                  size_t isotach_index) const;
+  NODISCARD auto to_string(size_t cycle,
+                           const Gahm::Datatypes::Date& start_date,
+                           size_t isotach_index) const -> std::string;
 
   void processIsotachRadii();
 
@@ -118,11 +125,11 @@ class AtcfSnap {
   void orderIsotachs();
 
  private:
-  static Gahm::Datatypes::Date parseDate(const std::string& date_str,
-                                         const std::string& tau_str);
+  static auto parseDate(const std::string& date_str, const std::string& tau_str)
+      -> Gahm::Datatypes::Date;
 
-  static Gahm::Atcf::AtcfIsotach parseIsotach(
-      const std::vector<std::string>& line);
+  static auto parseIsotach(const std::vector<std::string>& line)
+      -> Gahm::Atcf::AtcfIsotach;
 
   double m_central_pressure;
   double m_background_pressure;

--- a/src/atcf/AtcfSnap.h
+++ b/src/atcf/AtcfSnap.h
@@ -88,7 +88,7 @@ class AtcfSnap {
   NODISCARD auto getIsotachs() const
       -> const std::vector<Gahm::Atcf::AtcfIsotach>&;
 #endif
-  auto getIsotachs() -> std::vector<Gahm::Atcf::AtcfIsotach>&;
+  std::vector<Gahm::Atcf::AtcfIsotach> &getIsotachs();
 
   NODISCARD static auto basinFromString(const std::string& basin)
       -> Gahm::Atcf::AtcfSnap::BASIN;

--- a/src/datatypes/CircularArray.h
+++ b/src/datatypes/CircularArray.h
@@ -212,8 +212,7 @@ class CircularArray {
   /* @brief Returns the mod_floor of the index */
   template <typename Tp>
   static constexpr auto mod_floor(Tp position) noexcept -> unsigned {
-    return static_cast<unsigned>(
-        (static_cast<unsigned>(position) + array_size) % array_size);
+    return (static_cast<unsigned>(position) + array_size) % array_size;
   }
 };
 }  // namespace Gahm::Datatypes

--- a/src/datatypes/CircularArray.h
+++ b/src/datatypes/CircularArray.h
@@ -25,6 +25,12 @@
 #include <iostream>
 #include <vector>
 
+#ifdef SWIG
+#define NODISCARD
+#else
+#define NODISCARD [[nodiscard]]
+#endif
+
 namespace Gahm::Datatypes {
 
 /**
@@ -46,6 +52,31 @@ class CircularArray {
    */
   constexpr CircularArray() = default;
 
+  /* @brief Copy constructor
+   * @param[in] arr The array to copy
+   */
+  constexpr CircularArray(const CircularArray<T, array_size> &arr) = default;
+
+  /* @brief Move constructor
+   * @param[in] arr The array to move
+   */
+  constexpr CircularArray(CircularArray<T, array_size> &&arr) = default;
+
+  /* @brief Copy assignment operator
+   * @param[in] arr The array to copy
+   */
+  constexpr auto operator=(const CircularArray<T, array_size> &arr)
+      -> CircularArray<T, array_size> & = default;
+
+  /* @brief Move assignment operator
+   * @param[in] arr The array to move
+   */
+  constexpr auto operator=(CircularArray<T, array_size> &&arr)
+      -> CircularArray<T, array_size> & = default;
+
+  /* @brief Destructor */
+  ~CircularArray() = default;
+
   /*
    * @brief Constructor from std::array
    */
@@ -53,34 +84,20 @@ class CircularArray {
       : m_data(std::move(arr)) {}
 
   /* @brief Indexing operator */
-  constexpr T &operator[](int index) noexcept {
+  NODISCARD constexpr auto operator[](int index) noexcept -> T & {
     return m_data[mod_floor(index)];
   }
 
   /* @brief Indexing operator */
-  constexpr const T &operator[](int index) const noexcept {
+  NODISCARD constexpr auto operator[](int index) const noexcept -> const T & {
     return m_data[mod_floor(index)];
-  }
-
-  /* @brief Copy assignment operator */
-  Gahm::Datatypes::CircularArray<T, array_size> &operator=(
-      const Gahm::Datatypes::CircularArray<T, array_size> &arr) noexcept {
-    m_data = arr.m_data;
-    return *this;
-  }
-
-  /* @brief Copy assignment operator */
-  Gahm::Datatypes::CircularArray<T, array_size> &operator=(
-      const std::array<T, array_size> &arr) noexcept {
-    m_data = arr;
-    return *this;
   }
 
   /* @brief Returns an iterator to the mod_floor of the index */
   template <typename Tp>
   constexpr auto iterator_at(Tp position) const noexcept {
-    auto p = mod_floor(position);
-    return m_data.begin() + p;
+    auto pos = mod_floor(position);
+    return m_data.begin() + pos;
   }
 
   /* @brief Returns the value at the index without the mod_floor */
@@ -99,10 +116,10 @@ class CircularArray {
   constexpr void set(const std::array<T, array_size> &array) { m_data = array; }
 
   /* @brief Returns the front of the array */
-  constexpr auto front() noexcept { return m_data.front(); }
+  NODISCARD constexpr auto front() noexcept { return m_data.front(); }
 
   /* @brief Returns the back of the array */
-  constexpr auto back() noexcept { return m_data.back(); }
+  NODISCARD constexpr auto back() noexcept { return m_data.back(); }
 
   /* @brief Returns a pointer to the data */
   constexpr auto data() noexcept { return &m_data; }
@@ -111,79 +128,82 @@ class CircularArray {
   constexpr auto data() const noexcept { return &m_data; }
 
   /* @brief Return the data as a vector */
-  std::vector<T> asVector() const noexcept {
+  NODISCARD auto asVector() const noexcept -> std::vector<T> {
     return std::vector<T>(m_data.begin(), m_data.end());
   }
 
   /* @brief returns true if the array is empty */
-  constexpr auto empty() const noexcept { return m_data.empty(); }
+  NODISCARD constexpr auto empty() const noexcept { return m_data.empty(); }
 
   /* @brief returns the max size of the array */
-  constexpr auto max_size() const noexcept { return m_data.max_size(); }
+  NODISCARD constexpr auto max_size() const noexcept {
+    return m_data.max_size();
+  }
 
   /* @brief returns the size of the array */
-  constexpr auto size() const noexcept { return array_size; }
+  NODISCARD constexpr auto size() const noexcept { return array_size; }
 
   /* @brief Fills the array with a value */
   constexpr void fill(const T value) { m_data.fill(value); }
 
   /* @brief Returns an iterator to the beginning of the array */
-  constexpr auto begin() noexcept { return m_data.begin(); }
+  NODISCARD constexpr auto begin() noexcept { return m_data.begin(); }
 
   /* @brief Returns an iterator to the end of the array */
-  constexpr auto end() noexcept { return m_data.end(); }
+  NODISCARD constexpr auto end() noexcept { return m_data.end(); }
 
   /* @brief Returns a reverse iterator to the beginning of the array */
-  constexpr auto rbegin() noexcept { return m_data.rbegin(); }
+  NODISCARD constexpr auto rbegin() noexcept { return m_data.rbegin(); }
 
   /* @brief Returns a reverse iterator to the end of the array */
-  constexpr auto rend() noexcept { return m_data.rend(); }
+  NODISCARD constexpr auto rend() noexcept { return m_data.rend(); }
 
   /* @brief Returns an iterator to the beginning of the array */
-  constexpr auto begin() const noexcept { return m_data.cbegin(); }
+  NODISCARD constexpr auto begin() const noexcept { return m_data.cbegin(); }
 
   /* @brief Returns an iterator to the end of the array */
-  constexpr auto end() const noexcept { return m_data.cend(); }
+  NODISCARD constexpr auto end() const noexcept { return m_data.cend(); }
 
   /* @brief Returns a reverse iterator to the beginning of the array */
-  constexpr auto rbegin() const noexcept { return m_data.crbegin(); }
+  NODISCARD constexpr auto rbegin() const noexcept { return m_data.crbegin(); }
 
   /* @brief Returns a reverse iterator to the end of the array */
-  constexpr auto rend() const noexcept { return m_data.crend(); }
-
-  /* @brief Copy constructor
-   * @param[in] arr The array to copy
-   */
-  constexpr CircularArray(const CircularArray<T, array_size> &arr) = default;
+  NODISCARD constexpr auto rend() const noexcept { return m_data.crend(); }
 
   /* @brief Equality operator */
-  constexpr bool operator==(const CircularArray<T, array_size> &b) const {
-    return m_data == b.m_data;
+  NODISCARD constexpr auto operator==(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data == rhs.m_data;
   }
 
   /* @brief Not equal operator */
-  constexpr bool operator!=(const CircularArray<T, array_size> &b) const {
-    return m_data != b.m_data;
+  NODISCARD constexpr auto operator!=(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data != rhs.m_data;
   }
 
   /* @brief Less than operator */
-  constexpr bool operator<(const CircularArray<T, array_size> &b) const {
-    return m_data < b.m_data;
+  NODISCARD constexpr auto operator<(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data < rhs.m_data;
   }
 
   /* @brief Greater than operator */
-  constexpr bool operator>(const CircularArray<T, array_size> &b) const {
-    return m_data > b.m_data;
+  NODISCARD constexpr auto operator>(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data > rhs.m_data;
   }
 
   /* @brief Less than or equal to operator */
-  constexpr bool operator<=(const CircularArray<T, array_size> &b) const {
-    return m_data <= b.m_data;
+  NODISCARD constexpr auto operator<=(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data <= rhs.m_data;
   }
 
   /* @brief Greater than or equal to operator */
-  constexpr bool operator>=(const CircularArray<T, array_size> &b) const {
-    return m_data >= b.m_data;
+  NODISCARD constexpr auto operator>=(
+      const CircularArray<T, array_size> &rhs) const -> bool {
+    return m_data >= rhs.m_data;
   }
 
  private:
@@ -191,7 +211,7 @@ class CircularArray {
 
   /* @brief Returns the mod_floor of the index */
   template <typename Tp>
-  static constexpr unsigned mod_floor(Tp position) noexcept {
+  static constexpr auto mod_floor(Tp position) noexcept -> unsigned {
     return static_cast<unsigned>(
         (static_cast<unsigned>(position) + array_size) % array_size);
   }
@@ -199,16 +219,16 @@ class CircularArray {
 }  // namespace Gahm::Datatypes
 
 template <typename T, unsigned array_size>
-std::ostream &operator<<(
-    std::ostream &os,
-    const Gahm::Datatypes::CircularArray<T, array_size> &array) {
-  for (auto b = array.cbegin(); b != array.cend(); ++b) {
-    os << *(b);
-    if (b != array.cend() - 1) {
-      os << ", ";
+auto operator<<(std::ostream &stream,
+                const Gahm::Datatypes::CircularArray<T, array_size> &array)
+    -> std::ostream & {
+  for (auto val = array.cbegin(); val != array.cend(); ++val) {
+    stream << *(val);
+    if (val != array.cend() - 1) {
+      stream << ", ";
     }
   }
-  return os;
+  return stream;
 }
 
 #endif  // GAHM_CIRCULARARRAY_H

--- a/src/datatypes/Date.h
+++ b/src/datatypes/Date.h
@@ -38,20 +38,28 @@
 namespace Gahm::Datatypes {
 class Date {
  public:
+  static constexpr int hours_per_day = 24;
+  static constexpr int days_per_week = 7;
+  static constexpr int months_per_year = 12;
+  static constexpr int days_per_year_numerator = 146097;
+  static constexpr int days_per_year_denominator = 400;
+
   using milliseconds = std::chrono::milliseconds;
   using seconds = std::chrono::seconds;
   using minutes = std::chrono::minutes;
   using hours = std::chrono::hours;
-  using days = std::chrono::duration<
-      int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
-  using weeks =
+  using days =
       std::chrono::duration<int,
-                            std::ratio_multiply<std::ratio<7>, days::period>>;
+                            std::ratio_multiply<std::ratio<hours_per_day>,
+                                                std::chrono::hours::period>>;
+  using weeks = std::chrono::duration<
+      int, std::ratio_multiply<std::ratio<days_per_week>, days::period>>;
   using years = std::chrono::duration<
-      int, std::ratio_multiply<std::ratio<146097, 400>, days::period>>;
-  using months =
-      std::chrono::duration<int,
-                            std::ratio_divide<years::period, std::ratio<12>>>;
+      int, std::ratio_multiply<
+               std::ratio<days_per_year_numerator, days_per_year_denominator>,
+               days::period>>;
+  using months = std::chrono::duration<
+      int, std::ratio_divide<years::period, std::ratio<months_per_year>>>;
 
   Date();
 
@@ -69,71 +77,67 @@ class Date {
 
   //...operator overloads
 #ifndef SWIG
-  bool operator<(const Date &d) const;
-  bool operator>(const Date &d) const;
-  bool operator<=(const Date &d) const;
-  bool operator>=(const Date &d) const;
-  bool operator==(const Date &d) const;
-  bool operator!=(const Date &d) const;
-  Date &operator=(const Date &d) = default;
+  auto operator<(const Date &d) const -> bool;
+  auto operator>(const Date &d) const -> bool;
+  auto operator<=(const Date &d) const -> bool;
+  auto operator>=(const Date &d) const -> bool;
+  auto operator==(const Date &d) const -> bool;
+  auto operator!=(const Date &d) const -> bool;
+  auto operator=(const Date &d) -> Date & = default;
 
-  template <class T, typename std::enable_if<std::is_integral<T>::value>::type
-                         * = nullptr>
-  Date &operator+=(const T &rhs) {
+  template <class T, std::enable_if_t<std::is_integral_v<T>> * = nullptr>
+  auto operator+=(const T &rhs) -> Date & {
     this->m_datetime += Date::seconds(rhs);
     return *this;
   }
 
-  template <class T, typename std::enable_if<
-                         std::is_floating_point<T>::value>::type * = nullptr>
-  Date &operator+=(const T &rhs) {
-    this->m_datetime +=
-        Date::milliseconds(static_cast<long>(std::floor(rhs * 1000.0)));
+  template <class T, std::enable_if_t<std::is_floating_point_v<T>> * = nullptr>
+  auto operator+=(const T &rhs) -> Date & {
+    constexpr int milliseconds_per_second = 1000;
+    this->m_datetime += Date::milliseconds(
+        static_cast<long>(std::floor(rhs * milliseconds_per_second)));
     return *this;
   }
 
-  template <class T,
-            typename std::enable_if<!std::is_integral<T>::value &&
-                                    !std::is_floating_point<T>::value &&
-                                    !std::is_same<T, Date::years>::value &&
-                                    !std::is_same<T, Date::months>::value>::type
-                * = nullptr>
-  Date &operator+=(const T &rhs) {
+  template <
+      class T,
+      std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T> &&
+                       !std::is_same_v<T, Date::years> &&
+                       !std::is_same_v<T, Date::months>> * = nullptr>
+  auto operator+=(const T &rhs) -> Date & {
     this->m_datetime += rhs;
     return *this;
   }
 
-  Date &operator+=(const Date::years &rhs);
-  Date &operator+=(const Date::months &rhs);
+  auto operator+=(const Date::years &rhs) -> Date &;
+  auto operator+=(const Date::months &rhs) -> Date &;
 
-  template <class T, typename std::enable_if<std::is_integral<T>::value>::type
-                         * = nullptr>
-  Date &operator-=(const T &rhs) {
+  template <class T, std::enable_if_t<std::is_integral_v<T>> * = nullptr>
+  auto operator-=(const T &rhs) -> Date & {
     this->m_datetime -= Date::seconds(rhs);
     return *this;
   }
 
-  template <class T, typename std::enable_if<
-                         std::is_floating_point<T>::value>::type * = nullptr>
-  Date &operator-=(const T &rhs) {
-    this->m_datetime -=
-        Date::milliseconds(static_cast<long>(std::floor(rhs * 1000.0)));
+  template <class T, std::enable_if_t<std::is_floating_point_v<T>> * = nullptr>
+  auto operator-=(const T &rhs) -> Date & {
+    constexpr int milliseconds_per_second = 1000;
+    this->m_datetime -= Date::milliseconds(
+        static_cast<long>(std::floor(rhs * milliseconds_per_second)));
     return *this;
   }
 
-  template <class T,
-            typename std::enable_if<!std::is_integral<T>::value &&
-                                    !std::is_floating_point<T>::value &&
-                                    !std::is_same<T, Date::years>::value &&
-                                    !std::is_same<T, Date::months>::value>::type
-                * = nullptr>
-  Date &operator-=(const T &rhs) {
+  template <
+      class T,
+      std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T> &&
+                       !std::is_same_v<T, Date::years> &&
+                       !std::is_same_v<T, Date::months>> * = nullptr>
+  auto operator-=(const T &rhs) -> Date & {
     this->m_datetime -= rhs;
     return *this;
   }
 
-  Date &operator-=(const Date::years &rhs);
-  Date &operator-=(const Date::months &rhs);
+  auto operator-=(const Date::years &rhs) -> Date &;
+  auto operator-=(const Date::months &rhs) -> Date &;
 
 #endif
 
@@ -145,10 +149,16 @@ class Date {
   void addMonths(const long &value);
   void addYears(const long &value);
 
-  static Date maxDate() { return Date(3000, 1, 1, 0, 0, 0); }
-  static Date minDate() { return Date(1900, 1, 1, 0, 0, 0); }
+  static auto maxDate() -> Date {
+    constexpr int max_year = 3000;
+    return Date(max_year, 1, 1, 0, 0, 0);
+  }
+  static auto minDate() -> Date {
+    constexpr int min_year = 1900;
+    return Date(min_year, 1, 1, 0, 0, 0);
+  }
 
-  NODISCARD std::vector<long long> get() const;
+  NODISCARD auto get() const -> std::vector<long long>;
 
   void set(const std::vector<long long> &v);
   void set(const std::chrono::system_clock::time_point &t);
@@ -157,65 +167,66 @@ class Date {
            long long minute = 0, long long second = 0,
            long long millisecond = 0);
 
-  static Date fromSeconds(long seconds);
+  static auto fromSeconds(long seconds) -> Date;
 
   void fromMSeconds(long long mseconds);
 
-  NODISCARD long toSeconds() const;
+  NODISCARD auto toSeconds() const -> long;
 
-  NODISCARD long long toMSeconds() const;
+  NODISCARD auto toMSeconds() const -> long long;
 
-  NODISCARD int year() const;
+  NODISCARD auto year() const -> int;
   void setYear(int year);
 
-  NODISCARD unsigned month() const;
+  NODISCARD auto month() const -> unsigned;
   void setMonth(unsigned month);
 
-  NODISCARD unsigned day() const;
+  NODISCARD auto day() const -> unsigned;
   void setDay(unsigned day);
 
-  NODISCARD long long hour() const;
+  NODISCARD auto hour() const -> long long;
   void setHour(long long hour);
 
-  NODISCARD long long minute() const;
+  NODISCARD auto minute() const -> long long;
   void setMinute(long long minute);
 
-  NODISCARD long long second() const;
+  NODISCARD auto second() const -> long long;
   void setSecond(long long second);
 
-  NODISCARD long long millisecond() const;
+  NODISCARD auto millisecond() const -> long long;
   void setMillisecond(long long milliseconds);
 
-  NODISCARD static Date fromString(
+  NODISCARD static auto fromString(
       const std::string &datestr,
-      const std::string &format = "%Y-%m-%d %H:%M:%OS");
+      const std::string &format = "%Y-%m-%d %H:%M:%OS") -> Date;
 
-  NODISCARD std::string toString(
-      const std::string &format = "%Y-%m-%d %H:%M:%OS") const;
+  NODISCARD auto toString(
+      const std::string &format = "%Y-%m-%d %H:%M:%OS") const -> std::string;
 
-  NODISCARD std::chrono::system_clock::time_point time_point() const;
+  NODISCARD auto time_point() const -> std::chrono::system_clock::time_point;
 
-  static Date now();
+  static auto now() -> Date;
 
  private:
   std::chrono::system_clock::time_point m_datetime;
 };
 
 template <typename T>
-Date operator+(Date lhs, const T &rhs) {
+auto operator+(Date lhs, const T &rhs) -> Date {
   lhs += rhs;
   return lhs;
 }
 
 template <typename T>
-Date operator-(Date lhs, const T &rhs) {
+auto operator-(Date lhs, const T &rhs) -> Date {
   lhs -= rhs;
   return lhs;
 }
 }  // namespace Gahm::Datatypes
 
 #ifndef SWIG
-std::ostream &operator<<(std::ostream &os, const Gahm::Datatypes::Date &dt);
+auto operator<<(std::ostream &os, const Gahm::Datatypes::Date &dt)
+    -> std::ostream &;
 #endif
 
 #endif  // GAHMDATE_H

--- a/src/datatypes/Point.h
+++ b/src/datatypes/Point.h
@@ -32,19 +32,20 @@ class Point {
  public:
   Point() : m_x(0.0), m_y(0.0) {}
 
-  Point(double x, double y) : m_x(x), m_y(y) {}
+  Point(double x_position, double y_position)
+      : m_x(x_position), m_y(y_position) {}
 
-  NODISCARD double x() const { return m_x; }
-  NODISCARD double y() const { return m_y; }
+  NODISCARD auto x() const -> double { return m_x; }
+  NODISCARD auto y() const -> double { return m_y; }
 
-  void setX(double x) { m_x = x; }
-  void setY(double y) { m_y = y; }
+  void setX(double x_position) { m_x = x_position; }
+  void setY(double y_position) { m_y = y_position; }
 
-  bool operator==(const Point &rhs) const {
+  auto operator==(const Point &rhs) const -> bool {
     return m_x == rhs.m_x && m_y == rhs.m_y;
   }
 
-  bool operator!=(const Point &rhs) const { return !(rhs == *this); }
+  auto operator!=(const Point &rhs) const -> bool { return !(rhs == *this); }
 
  private:
   double m_x;

--- a/src/datatypes/PointCloud.h
+++ b/src/datatypes/PointCloud.h
@@ -23,6 +23,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <vector>
 
 #include "datatypes/Point.h"
@@ -39,33 +40,27 @@ class PointCloud {
  public:
   PointCloud() = default;
 
-  PointCloud(const std::vector<double> &x, const std::vector<double> &y) {
-    assert(x.size() == y.size());
-    m_points.reserve(x.size());
-    for (size_t i = 0; i < x.size(); i++) {
-      m_points.emplace_back(x[i], y[i]);
-    }
-  }
-
-  PointCloud(const size_t size, const double x[], const double y[]) {
-    m_points.reserve(size);
-    for (size_t i = 0; i < size; i++) {
-      m_points.emplace_back(x[i], y[i]);
+  PointCloud(const std::vector<double> &x_positions,
+             const std::vector<double> &y_positions) {
+    assert(x_positions.size() == y_positions.size());
+    m_points.reserve(x_positions.size());
+    for (size_t i = 0; i < x_positions.size(); i++) {
+      m_points.emplace_back(x_positions[i], y_positions[i]);
     }
   }
 
   NODISCARD const std::vector<Point> &points() const { return m_points; }
 
-  NODISCARD std::vector<double> x() const {
-    std::vector<double> x;
-    x.reserve(m_points.size());
+  NODISCARD auto x() const -> std::vector<double> {
+    std::vector<double> x_vals;
+    x_vals.reserve(m_points.size());
     for (const auto &point : m_points) {
-      x.push_back(point.x());
+      x_vals.push_back(point.x());
     }
-    return x;
+    return x_vals;
   }
 
-  NODISCARD std::vector<double> y() const {
+  NODISCARD auto y() const -> std::vector<double> {
     std::vector<double> y;
     y.reserve(m_points.size());
     for (const auto &point : m_points) {
@@ -77,14 +72,17 @@ class PointCloud {
   void addPoint(const Gahm::Datatypes::Point &point) {
     m_points.push_back(point);
   }
-  void addPoint(double x, double y) { m_points.emplace_back(x, y); }
+
+  void addPoint(double x_pos, double y_pos) {
+    m_points.emplace_back(x_pos, y_pos);
+  }
 
   void clear() { m_points.clear(); }
 
   void removePoint(const Gahm::Datatypes::Point &point) {
-    auto it = std::find(m_points.begin(), m_points.end(), point);
-    if (it != m_points.end()) {
-      m_points.erase(it);
+    auto iter = std::find(m_points.begin(), m_points.end(), point);
+    if (iter != m_points.end()) {
+      m_points.erase(iter);
     }
   }
 
@@ -103,26 +101,29 @@ class PointCloud {
   auto back() { return m_points.back(); }
   NODISCARD auto back() const { return m_points.back(); }
 
-  NODISCARD bool operator==(const Gahm::Datatypes::PointCloud &rhs) const {
+  NODISCARD auto operator==(const Gahm::Datatypes::PointCloud &rhs) const
+      -> bool {
     return m_points == rhs.m_points;
   }
 
-  NODISCARD bool operator!=(const Gahm::Datatypes::PointCloud &rhs) const {
+  NODISCARD auto operator!=(const Gahm::Datatypes::PointCloud &rhs) const
+      -> bool {
     return !(rhs == *this);
   }
 
-  NODISCARD Gahm::Datatypes::Point &operator[](size_t index) {
+  NODISCARD auto operator[](size_t index) -> Gahm::Datatypes::Point & {
     return m_points[index];
   }
-  NODISCARD const Gahm::Datatypes::Point &operator[](size_t index) const {
+  NODISCARD auto operator[](size_t index) const
+      -> const Gahm::Datatypes::Point & {
     return m_points[index];
   }
 
 #endif
 
-  NODISCARD size_t size() const { return m_points.size(); }
+  NODISCARD auto size() const -> size_t { return m_points.size(); }
 
-  NODISCARD bool empty() const { return m_points.empty(); }
+  NODISCARD auto empty() const -> bool { return m_points.empty(); }
 
  private:
   std::vector<Gahm::Datatypes::Point> m_points;

--- a/src/datatypes/PointPosition.h
+++ b/src/datatypes/PointPosition.h
@@ -21,8 +21,6 @@
 #ifndef GAHM_POINTPOSITION_H
 #define GAHM_POINTPOSITION_H
 
-#include <cstddef>
-
 #ifndef SWIG
 #define NODISCARD [[nodiscard]]
 #else
@@ -43,17 +41,17 @@ class PointPosition {
         m_isotach_adjacent(isotach_adjacent),
         m_isotach_adjacent_weight(isotach_adjacent_weight) {}
 
-  NODISCARD int isotach() const { return m_isotach; }
+  NODISCARD auto isotach() const -> int { return m_isotach; }
 
-  NODISCARD int quadrant() const { return m_quadrant; }
+  NODISCARD auto quadrant() const -> int { return m_quadrant; }
 
-  NODISCARD double isotach_weight() const { return m_isotach_weight; }
+  NODISCARD auto isotach_weight() const -> double { return m_isotach_weight; }
 
-  NODISCARD double quadrant_weight() const { return m_quadrant_weight; }
+  NODISCARD auto quadrant_weight() const -> double { return m_quadrant_weight; }
 
-  NODISCARD int isotach_adjacent() const { return m_isotach_adjacent; }
+  NODISCARD auto isotach_adjacent() const -> int { return m_isotach_adjacent; }
 
-  NODISCARD double isotach_adjacent_weight() const {
+  NODISCARD auto isotach_adjacent_weight() const -> double {
     return m_isotach_adjacent_weight;
   }
 

--- a/src/datatypes/Uvp.h
+++ b/src/datatypes/Uvp.h
@@ -76,27 +76,27 @@ class Uvp {
         m_quadrant(quadrant),
         m_isotach(isotach) {}
 
-  NODISCARD double u() const { return m_u; }
+  NODISCARD auto u() const -> double { return m_u; }
 
-  NODISCARD double v() const { return m_v; }
+  NODISCARD auto v() const -> double { return m_v; }
 
-  NODISCARD double p() const { return m_p; }
+  NODISCARD auto p() const -> double { return m_p; }
 
-  NODISCARD double azimuth() const { return m_azimuth; }
+  NODISCARD auto azimuth() const -> double { return m_azimuth; }
 
-  NODISCARD double distance() const { return m_distance; }
+  NODISCARD auto distance() const -> double { return m_distance; }
 
-  NODISCARD double tsx() const { return m_tsx; }
+  NODISCARD auto tsx() const -> double { return m_tsx; }
 
-  NODISCARD double tsy() const { return m_tsy; }
+  NODISCARD auto tsy() const -> double { return m_tsy; }
 
-  NODISCARD double quadrant_weight() const { return m_quadrant_weight; }
+  NODISCARD auto quadrant_weight() const -> double { return m_quadrant_weight; }
 
-  NODISCARD double isotach_weight() const { return m_isotach_weight; }
+  NODISCARD auto isotach_weight() const -> double { return m_isotach_weight; }
 
-  NODISCARD int quadrant() const { return m_quadrant; }
+  NODISCARD auto quadrant() const -> int { return m_quadrant; }
 
-  NODISCARD int isotach() const { return m_isotach; }
+  NODISCARD auto isotach() const -> int { return m_isotach; }
 
   void setU(double u) { m_u = u; }
 

--- a/src/datatypes/VortexSolution.h
+++ b/src/datatypes/VortexSolution.h
@@ -62,11 +62,12 @@ class VortexSolution {
   auto at(size_t index) -> Gahm::Datatypes::Uvp & {
     return this->operator[](index);
   }
-  NODISCARD auto at(size_t index) const -> const Gahm::Datatypes::Uvp & {
+
+  NODISCARD const Gahm::Datatypes::Uvp &at(size_t index) const {
     return this->operator[](index);
   }
 
-  NODISCARD auto uvp() const -> const std::vector<Gahm::Datatypes::Uvp> & {
+  NODISCARD const std::vector<Gahm::Datatypes::Uvp> &uvp() const {
     return m_uvp;
   }
 

--- a/src/datatypes/VortexSolution.h
+++ b/src/datatypes/VortexSolution.h
@@ -59,9 +59,7 @@ class VortexSolution {
   }
 #endif
 
-  auto at(size_t index) -> Gahm::Datatypes::Uvp & {
-    return this->operator[](index);
-  }
+  Gahm::Datatypes::Uvp &at(size_t index) { return this->operator[](index); }
 
   NODISCARD const Gahm::Datatypes::Uvp &at(size_t index) const {
     return this->operator[](index);

--- a/src/datatypes/VortexSolution.h
+++ b/src/datatypes/VortexSolution.h
@@ -25,7 +25,6 @@
 #include <vector>
 
 #include "Uvp.h"
-#include "physical/Constants.h"
 
 #ifdef SWIG
 #define NODISCARD
@@ -40,9 +39,9 @@ class VortexSolution {
 
   explicit VortexSolution(size_t size) { m_uvp.reserve(size); }
 
-  NODISCARD size_t size() const { return m_uvp.size(); }
+  NODISCARD auto size() const -> size_t { return m_uvp.size(); }
 
-  NODISCARD bool empty() const { return m_uvp.empty(); }
+  NODISCARD auto empty() const -> bool { return m_uvp.empty(); }
 
   void resize(size_t size, const Gahm::Datatypes::Uvp &value) {
     m_uvp.resize(size, value);
@@ -51,18 +50,23 @@ class VortexSolution {
   void reserve(size_t size) { m_uvp.reserve(size); }
 
 #ifndef SWIG
-  Gahm::Datatypes::Uvp &operator[](size_t index) { return m_uvp[index]; }
-  NODISCARD const Gahm::Datatypes::Uvp &operator[](size_t index) const {
+  auto operator[](size_t index) -> Gahm::Datatypes::Uvp & {
+    return m_uvp[index];
+  }
+  NODISCARD auto operator[](size_t index) const
+      -> const Gahm::Datatypes::Uvp & {
     return m_uvp[index];
   }
 #endif
 
-  Gahm::Datatypes::Uvp &at(size_t index) { return this->operator[](index); }
-  NODISCARD const Gahm::Datatypes::Uvp &at(size_t index) const {
+  auto at(size_t index) -> Gahm::Datatypes::Uvp & {
+    return this->operator[](index);
+  }
+  NODISCARD auto at(size_t index) const -> const Gahm::Datatypes::Uvp & {
     return this->operator[](index);
   }
 
-  NODISCARD const std::vector<Gahm::Datatypes::Uvp> &uvp() const {
+  NODISCARD auto uvp() const -> const std::vector<Gahm::Datatypes::Uvp> & {
     return m_uvp;
   }
 
@@ -78,7 +82,7 @@ class VortexSolution {
   auto back() { return m_uvp.back(); }
 #endif
 
-  NODISCARD std::vector<double> u() const {
+  NODISCARD auto u() const -> std::vector<double> {
     std::vector<double> u;
     u.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -87,7 +91,7 @@ class VortexSolution {
     return u;
   }
 
-  NODISCARD std::vector<double> v() const {
+  NODISCARD auto v() const -> std::vector<double> {
     std::vector<double> v;
     v.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -96,7 +100,7 @@ class VortexSolution {
     return v;
   }
 
-  NODISCARD std::vector<double> p() const {
+  NODISCARD auto p() const -> std::vector<double> {
     std::vector<double> p;
     p.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -105,7 +109,7 @@ class VortexSolution {
     return p;
   }
 
-  NODISCARD std::vector<double> azimuth() const {
+  NODISCARD auto azimuth() const -> std::vector<double> {
     std::vector<double> azimuth;
     azimuth.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -114,7 +118,7 @@ class VortexSolution {
     return azimuth;
   }
 
-  NODISCARD std::vector<double> distance() const {
+  NODISCARD auto distance() const -> std::vector<double> {
     std::vector<double> distance;
     distance.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -123,7 +127,7 @@ class VortexSolution {
     return distance;
   }
 
-  NODISCARD std::vector<double> tsx() const {
+  NODISCARD auto tsx() const -> std::vector<double> {
     std::vector<double> tsx;
     tsx.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -132,7 +136,7 @@ class VortexSolution {
     return tsx;
   }
 
-  NODISCARD std::vector<double> tsy() const {
+  NODISCARD auto tsy() const -> std::vector<double> {
     std::vector<double> tsy;
     tsy.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -141,7 +145,7 @@ class VortexSolution {
     return tsy;
   }
 
-  NODISCARD std::vector<double> quadrant_weight() const {
+  NODISCARD auto quadrant_weight() const -> std::vector<double> {
     std::vector<double> quadrant_weight;
     quadrant_weight.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -150,7 +154,7 @@ class VortexSolution {
     return quadrant_weight;
   }
 
-  NODISCARD std::vector<double> isotach_weight() const {
+  NODISCARD auto isotach_weight() const -> std::vector<double> {
     std::vector<double> isotach_weight;
     isotach_weight.reserve(m_uvp.size());
     for (const auto &i : m_uvp) {
@@ -159,20 +163,20 @@ class VortexSolution {
     return isotach_weight;
   }
 
-  NODISCARD std::vector<double> quadrant() const {
+  NODISCARD auto quadrant() const -> std::vector<double> {
     std::vector<double> quadrant;
     quadrant.reserve(m_uvp.size());
-    for (const auto &i : m_uvp) {
-      quadrant.push_back(i.quadrant());
+    for (const auto &iter : m_uvp) {
+      quadrant.push_back(iter.quadrant());
     }
     return quadrant;
   }
 
-  NODISCARD std::vector<double> isotach() const {
+  NODISCARD auto isotach() const -> std::vector<double> {
     std::vector<double> isotach;
     isotach.reserve(m_uvp.size());
-    for (const auto &i : m_uvp) {
-      isotach.push_back(i.isotach());
+    for (const auto &iter : m_uvp) {
+      isotach.push_back(iter.isotach());
     }
     return isotach;
   }

--- a/src/datatypes/WindGrid.h
+++ b/src/datatypes/WindGrid.h
@@ -24,7 +24,6 @@
 #include <cstdlib>
 #include <vector>
 
-#include "datatypes/Point.h"
 #include "datatypes/PointCloud.h"
 
 #ifdef SWIG
@@ -39,8 +38,8 @@ class WindGrid {
   WindGrid(double xll, double yll, double dx, double dy, size_t nx, size_t ny)
       : m_xll(xll), m_yll(yll), m_dx(dx), m_dy(dy), m_nx(nx), m_ny(ny) {}
 
-  static WindGrid fromCorners(double xll, double yll, double xur, double yur,
-                              double dx, double dy) {
+  static auto fromCorners(double xll, double yll, double xur, double yur,
+                          double dx, double dy) -> WindGrid {
     return {xll,
             yll,
             dx,
@@ -49,12 +48,12 @@ class WindGrid {
             static_cast<size_t>((yur - yll) / dy)};
   }
 
-  NODISCARD double xll() const { return m_xll; }
-  NODISCARD double yll() const { return m_yll; }
-  NODISCARD double dx() const { return m_dx; }
-  NODISCARD double dy() const { return m_dy; }
-  NODISCARD size_t nx() const { return m_nx; }
-  NODISCARD size_t ny() const { return m_ny; }
+  NODISCARD auto xll() const -> double { return m_xll; }
+  NODISCARD auto yll() const -> double { return m_yll; }
+  NODISCARD auto dx() const -> double { return m_dx; }
+  NODISCARD auto dy() const -> double { return m_dy; }
+  NODISCARD auto nx() const -> size_t { return m_nx; }
+  NODISCARD auto ny() const -> size_t { return m_ny; }
 
   void setXll(double xll) { m_xll = xll; }
   void setYll(double yll) { m_yll = yll; }
@@ -63,14 +62,14 @@ class WindGrid {
   void setNx(size_t nx) { m_nx = nx; }
   void setNy(size_t ny) { m_ny = ny; }
 
-  NODISCARD double x(size_t i) const {
+  NODISCARD auto x(size_t i) const -> double {
     return m_xll + static_cast<double>(i) * m_dx;
   }
-  NODISCARD double y(size_t j) const {
+  NODISCARD auto y(size_t j) const -> double {
     return m_yll + static_cast<double>(j) * m_dy;
   }
 
-  NODISCARD std::vector<double> x_vector() const {
+  NODISCARD auto x_vector() const -> std::vector<double> {
     std::vector<double> x(m_nx);
     for (size_t i = 0; i < m_nx; i++) {
       x[i] = m_xll + static_cast<double>(i) * m_dx;
@@ -78,7 +77,7 @@ class WindGrid {
     return x;
   }
 
-  NODISCARD std::vector<double> y_vector() const {
+  NODISCARD auto y_vector() const -> std::vector<double> {
     std::vector<double> y(m_ny);
     for (size_t j = 0; j < m_ny; j++) {
       y[j] = m_yll + static_cast<double>(j) * m_dy;
@@ -86,7 +85,7 @@ class WindGrid {
     return y;
   }
 
-  NODISCARD Gahm::Datatypes::PointCloud points() const {
+  NODISCARD auto points() const -> Gahm::Datatypes::PointCloud {
     auto xv = x_vector();
     auto yv = y_vector();
     Gahm::Datatypes::PointCloud points;
@@ -99,7 +98,7 @@ class WindGrid {
     return points;
   }
 
-  NODISCARD std::vector<std::vector<double>> x_grid() const {
+  NODISCARD auto x_grid() const -> std::vector<std::vector<double>> {
     std::vector<std::vector<double>> x_g;
     x_g.reserve(m_nx);
     for (size_t i = 0; i < m_nx; i++) {
@@ -111,7 +110,7 @@ class WindGrid {
     return x_g;
   }
 
-  NODISCARD std::vector<std::vector<double>> y_grid() const {
+  NODISCARD auto y_grid() const -> std::vector<std::vector<double>> {
     std::vector<std::vector<double>> y_g;
     y_g.reserve(m_nx);
     for (size_t i = 0; i < m_nx; i++) {

--- a/src/fortran/gahm_fortran.cpp
+++ b/src/fortran/gahm_fortran.cpp
@@ -77,7 +77,10 @@ long gahm_create_ftn(char *filename, long size, double *x, double *y,
                      bool quiet) {
   g_counter++;
   std::string filename_str(filename);
-  auto point_cloud = Gahm::Datatypes::PointCloud(size, x, y);
+  std::vector<double> x_pos(x, x + size);
+  std::vector<double> y_pos(y, y + size);
+
+  auto point_cloud = Gahm::Datatypes::PointCloud(x_pos, y_pos);
   g_gahm_instances[g_counter] =
       std::make_unique<gahm_instance>(filename_str, point_cloud, quiet);
   return g_counter;

--- a/src/gahm/GahmEquations.cpp
+++ b/src/gahm/GahmEquations.cpp
@@ -47,14 +47,14 @@ auto Gahm::Solver::GahmEquations::GahmFunction(
     double radius_to_max_wind, double vmax_at_boundary_layer,
     double isotach_windspeed_at_boundary_layer, double distance,
     double coriolis_force, double gahm_holland_b, double phi) -> double {
-  const auto ro = Gahm::Physical::Atmospheric::rossbyNumber(
+  const auto rossby = Gahm::Physical::Atmospheric::rossbyNumber(
       vmax_at_boundary_layer, radius_to_max_wind, coriolis_force);
   const auto rmbg = std::pow(radius_to_max_wind / distance, gahm_holland_b);
   const auto sign_of_coriolis = coriolis_force >= 0.0 ? 1.0 : -1.0;
   return (sign_of_coriolis *
               std::sqrt(std::pow(vmax_at_boundary_layer, 2.0) *
-                            (1.0 + 1.0 / ro) * std::exp(phi * (1.0 - rmbg)) *
-                            rmbg +
+                            (1.0 + 1.0 / rossby) *
+                            std::exp(phi * (1.0 - rmbg)) * rmbg +
                         std::pow((distance * coriolis_force) / 2.0, 2.0)) -
           (distance * coriolis_force) / 2.0) -
          isotach_windspeed_at_boundary_layer;

--- a/src/gahm/GahmEquations.cpp
+++ b/src/gahm/GahmEquations.cpp
@@ -20,7 +20,9 @@
 //
 #include "GahmEquations.h"
 
-#include <iostream>
+#include <cmath>
+
+#include "physical/Atmospheric.h"
 
 /**
  * Function to compute radius to max wind \f$V_g(r)\f$
@@ -41,10 +43,10 @@
  * @param gahm_holland_b GAHM Holland B
  * @return Solution to gradient wind
  */
-double Gahm::Solver::GahmEquations::GahmFunction(
+auto Gahm::Solver::GahmEquations::GahmFunction(
     double radius_to_max_wind, double vmax_at_boundary_layer,
     double isotach_windspeed_at_boundary_layer, double distance,
-    double coriolis_force, double gahm_holland_b, double phi) {
+    double coriolis_force, double gahm_holland_b, double phi) -> double {
   const auto ro = Gahm::Physical::Atmospheric::rossbyNumber(
       vmax_at_boundary_layer, radius_to_max_wind, coriolis_force);
   const auto rmbg = std::pow(radius_to_max_wind / distance, gahm_holland_b);
@@ -74,10 +76,10 @@ double Gahm::Solver::GahmEquations::GahmFunction(
  * This function is called when the phi value is not known and must be
  * computed
  */
-double Gahm::Solver::GahmEquations::GahmFunction(
+auto Gahm::Solver::GahmEquations::GahmFunction(
     double radius_to_max_wind, double vmax_at_boundary_layer,
     double isotach_windspeed_at_boundary_layer, double distance,
-    double coriolis_force, double gahm_holland_b) {
+    double coriolis_force, double gahm_holland_b) -> double {
   const auto phi_local =
       GahmEquations::phi(vmax_at_boundary_layer, radius_to_max_wind,
                          gahm_holland_b, coriolis_force);
@@ -104,10 +106,10 @@ double Gahm::Solver::GahmEquations::GahmFunction(
  * @param gahm_holland_b GAHM Holland B parameter
  * @return Solution to first derivative
  */
-double Gahm::Solver::GahmEquations::GahmFunctionDerivative(
+auto Gahm::Solver::GahmEquations::GahmFunctionDerivative(
     double radius_to_max_wind, double vmax_at_boundary_layer,
     double isotach_radius, double coriolis_force, double gahm_holland_b,
-    double phi) {
+    double phi) -> double {
   const auto f3 = std::pow(radius_to_max_wind / isotach_radius, gahm_holland_b);
   const auto f4 =
       std::pow(radius_to_max_wind / isotach_radius, gahm_holland_b - 1.0);
@@ -130,9 +132,10 @@ double Gahm::Solver::GahmEquations::GahmFunctionDerivative(
   return (a + b - c) / d;
 }
 
-double Gahm::Solver::GahmEquations::GahmFunctionDerivative(
+auto Gahm::Solver::GahmEquations::GahmFunctionDerivative(
     double radius_to_max_wind, double vmax_at_boundary_layer,
-    double isotach_radius, double coriolis_force, double gahm_holland_b) {
+    double isotach_radius, double coriolis_force, double gahm_holland_b)
+    -> double {
   const auto phi =
       GahmEquations::phi(vmax_at_boundary_layer, radius_to_max_wind,
                          gahm_holland_b, coriolis_force);
@@ -141,20 +144,18 @@ double Gahm::Solver::GahmEquations::GahmFunctionDerivative(
                                 phi);
 }
 
-double Gahm::Solver::GahmEquations::GahmPressure(
+auto Gahm::Solver::GahmEquations::GahmPressure(
     double central_pressure, double background_pressure, double distance,
-    double radius_to_max_winds, double gahm_holland_b, double phi) {
+    double radius_to_max_winds, double gahm_holland_b, double phi) -> double {
   return central_pressure +
          (background_pressure - central_pressure) *
              std::exp(-phi *
                       std::pow(radius_to_max_winds / distance, gahm_holland_b));
 }
 
-double Gahm::Solver::GahmEquations::GahmWindSpeed(double radius_to_max_wind,
-                                                  double vmax_at_boundary_layer,
-                                                  double distance,
-                                                  double coriolis,
-                                                  double gahm_holland_b) {
+auto Gahm::Solver::GahmEquations::GahmWindSpeed(
+    double radius_to_max_wind, double vmax_at_boundary_layer, double distance,
+    double coriolis, double gahm_holland_b) -> double {
   return Gahm::Solver::GahmEquations::GahmFunction(
       radius_to_max_wind, vmax_at_boundary_layer, 0.0, distance, coriolis,
       gahm_holland_b);

--- a/src/gahm/GahmEquations.h
+++ b/src/gahm/GahmEquations.h
@@ -22,36 +22,40 @@
 #define GAHM_SRC_GAHMEQUATIONS_H_
 
 #include <cassert>
+#include <cmath>
 
 #include "physical/Atmospheric.h"
 
 namespace Gahm::Solver::GahmEquations {
 
-double GahmFunction(double radius_to_max_wind, double vmax_at_boundary_layer,
-                    double isotach_windspeed_at_boundary_layer, double distance,
-                    double coriolis_force, double gahm_holland_b, double phi);
+auto GahmFunction(double radius_to_max_wind, double vmax_at_boundary_layer,
+                  double isotach_windspeed_at_boundary_layer, double distance,
+                  double coriolis_force, double gahm_holland_b, double phi)
+    -> double;
 
-double GahmFunction(double radius_to_max_wind, double vmax_at_boundary_layer,
-                    double isotach_windspeed_at_boundary_layer, double distance,
-                    double coriolis_force, double gahm_holland_b);
+auto GahmFunction(double radius_to_max_wind, double vmax_at_boundary_layer,
+                  double isotach_windspeed_at_boundary_layer, double distance,
+                  double coriolis_force, double gahm_holland_b) -> double;
 
-double GahmFunctionDerivative(double radius_to_max_wind,
-                              double vmax_at_boundary_layer,
-                              double isotach_windspeed_at_boundary_layer,
-                              double coriolis_force, double gahm_holland_b,
-                              double phi);
+auto GahmFunctionDerivative(double radius_to_max_wind,
+                            double vmax_at_boundary_layer,
+                            double isotach_windspeed_at_boundary_layer,
+                            double coriolis_force, double gahm_holland_b,
+                            double phi) -> double;
 
-double GahmFunctionDerivative(double radius_to_max_wind,
-                              double vmax_at_boundary_layer,
-                              double isotach_windspeed_at_boundary_layer,
-                              double coriolis_force, double gahm_holland_b);
+auto GahmFunctionDerivative(double radius_to_max_wind,
+                            double vmax_at_boundary_layer,
+                            double isotach_windspeed_at_boundary_layer,
+                            double coriolis_force, double gahm_holland_b)
+    -> double;
 
-double GahmPressure(double central_pressure, double background_pressure,
-                    double distance, double radius_to_max_winds,
-                    double gahm_holland_b, double phi);
+auto GahmPressure(double central_pressure, double background_pressure,
+                  double distance, double radius_to_max_winds,
+                  double gahm_holland_b, double phi) -> double;
 
-double GahmWindSpeed(double radius_to_max_wind, double vmax_at_boundary_layer,
-                     double distance, double coriolis, double gahm_holland_b);
+auto GahmWindSpeed(double radius_to_max_wind, double vmax_at_boundary_layer,
+                   double distance, double coriolis, double gahm_holland_b)
+    -> double;
 
 /**
  * Compute the GAHM phi parameter
@@ -61,7 +65,7 @@ double GahmWindSpeed(double radius_to_max_wind, double vmax_at_boundary_layer,
  * @param fc coriolis force
  * @return phi
  */
-constexpr double phi(double vmax, double rmax, double bg, double fc) {
+constexpr auto phi(double vmax, double rmax, double bg, double fc) -> double {
   assert(fc > 0.0);
   assert(vmax > 0.0);
   assert(rmax > 0.0);
@@ -79,8 +83,8 @@ constexpr double phi(double vmax, double rmax, double bg, double fc) {
  * @param phi GAHM Phi parameter
  * @return GAHM Holland B
  */
-static double bg(double vmax, double rmax, double p0, double pinf, double fc,
-                 double phi) {
+static auto bg(double vmax, double rmax, double p0, double pinf, double fc,
+               double phi) -> double {
   auto b = Gahm::Physical::Atmospheric::calcHollandB(vmax, p0, pinf);
   auto ro = Gahm::Physical::Atmospheric::rossbyNumber(vmax, rmax, fc);
   auto bg = (b * ((1 + 1 / ro) * std::exp(phi - 1)) / phi);

--- a/src/gahm/GahmEquations.h
+++ b/src/gahm/GahmEquations.h
@@ -62,15 +62,17 @@ auto GahmWindSpeed(double radius_to_max_wind, double vmax_at_boundary_layer,
  * @param vmax maximum storm wind velocity
  * @param rmax radius to max winds
  * @param b GAHM holland b parameter
- * @param fc coriolis force
+ * @param f_coriolis coriolis force
  * @return phi
  */
-constexpr auto phi(double vmax, double rmax, double bg, double fc) -> double {
-  assert(fc > 0.0);
+constexpr auto phi(double vmax, double rmax, double gahm_b, double f_coriolis)
+    -> double {
+  assert(f_coriolis > 0.0);
   assert(vmax > 0.0);
   assert(rmax > 0.0);
-  auto rossby = Gahm::Physical::Atmospheric::rossbyNumber(vmax, rmax, fc);
-  return 1.0 + (1.0 / (rossby * bg * (1.0 + 1.0 / rossby)));
+  auto rossby =
+      Gahm::Physical::Atmospheric::rossbyNumber(vmax, rmax, f_coriolis);
+  return 1.0 + (1.0 / (rossby * gahm_b * (1.0 + 1.0 / rossby)));
 }
 
 /**
@@ -78,17 +80,20 @@ constexpr auto phi(double vmax, double rmax, double bg, double fc) -> double {
  * @param vmax maximum storm wind velocity
  * @param rmax radius to maximum winds
  * @param dp pressure deficit
- * @param fc coriolis force
+ * @param f_coriolis coriolis force
  * @param bg current value for GAHM Holland B
  * @param phi GAHM Phi parameter
  * @return GAHM Holland B
  */
-static auto bg(double vmax, double rmax, double p0, double pinf, double fc,
-               double phi) -> double {
-  auto b = Gahm::Physical::Atmospheric::calcHollandB(vmax, p0, pinf);
-  auto ro = Gahm::Physical::Atmospheric::rossbyNumber(vmax, rmax, fc);
-  auto bg = (b * ((1 + 1 / ro) * std::exp(phi - 1)) / phi);
-  return bg;
+static auto gahm_b(double vmax, double rmax, double p_center,
+                   double p_background, double f_coriolis, double phi)
+    -> double {
+  auto holland_b =
+      Gahm::Physical::Atmospheric::calcHollandB(vmax, p_center, p_background);
+  auto rossby =
+      Gahm::Physical::Atmospheric::rossbyNumber(vmax, rmax, f_coriolis);
+  auto gahm_b = (holland_b * ((1 + 1 / rossby) * std::exp(phi - 1)) / phi);
+  return gahm_b;
 }
 }  // namespace Gahm::Solver::GahmEquations
 #endif  // GAHM_SRC_GAHMEQUATIONS_H_

--- a/src/gahm/GahmRadiusSolver.cpp
+++ b/src/gahm/GahmRadiusSolver.cpp
@@ -20,7 +20,12 @@
 //
 #include "gahm/GahmRadiusSolver.h"
 
+#include <limits>
+#include <string>
+
+#include "boost/math/policies/error_handling.hpp"
 #include "boost/math/tools/roots.hpp"
+#include "boost/throw_exception.hpp"
 
 namespace Gahm::Solver {
 
@@ -43,11 +48,13 @@ GahmRadiusSolver::GahmRadiusSolver(double isotach_radius, double isotach_speed,
  * @param guess guess for solution
  * @return radius to maximum winds
  */
-double GahmRadiusSolver::solve(double lower, double upper, double guess) const {
-  auto it = m_max_it;
+auto GahmRadiusSolver::solve(double lower, double upper, double guess) const
+    -> double {
+  auto iter = m_max_it;
   try {
     return boost::math::tools::newton_raphson_iterate(
-        m_solver, guess, lower, upper, std::numeric_limits<double>::digits, it);
+        m_solver, guess, lower, upper, std::numeric_limits<double>::digits,
+        iter);
   } catch (const boost::wrapexcept<boost::math::evaluation_error> &e) {
     auto error = std::string("Unable to solve for radius to maximum winds: " +
                              std::string(e.what()));
@@ -60,11 +67,11 @@ double GahmRadiusSolver::solve(double lower, double upper, double guess) const {
  * iterations
  * @param bg GAHM Holland B
  */
-void GahmRadiusSolver::setBg(double bg) { m_solver.setBg(bg); }
+void GahmRadiusSolver::setBg(double b_gahm) { m_solver.setBg(b_gahm); }
 
 /**
  * Returns the current GAHM Holland B parameter
  * @return GAHM Holland B
  */
-double GahmRadiusSolver::bg() const { return m_solver.bg(); }
+auto GahmRadiusSolver::bg() const -> double { return m_solver.bg(); }
 }  // namespace Gahm::Solver

--- a/src/gahm/GahmRadiusSolver.cpp
+++ b/src/gahm/GahmRadiusSolver.cpp
@@ -61,8 +61,8 @@ auto GahmRadiusSolver::solve(double lower, double upper, double guess) const
         m_solver, guess, lower, upper, std::numeric_limits<double>::digits,
         iter);
   } catch (const boost::wrapexcept<boost::math::evaluation_error> &e) {
-    auto error = std::string("Unable to solve for radius to maximum winds: " +
-                             std::string(e.what()));
+    auto error =
+        "Unable to solve for radius to maximum winds: " + std::string(e.what());
     throw boost::math::evaluation_error(error);
   }
 }

--- a/src/gahm/GahmRadiusSolver.cpp
+++ b/src/gahm/GahmRadiusSolver.cpp
@@ -20,12 +20,15 @@
 //
 #include "gahm/GahmRadiusSolver.h"
 
+#include <cstddef>
 #include <limits>
 #include <string>
 
 #include "boost/math/policies/error_handling.hpp"
 #include "boost/math/tools/roots.hpp"
 #include "boost/throw_exception.hpp"
+
+constexpr size_t c_max_solver_iterations = 200;
 
 namespace Gahm::Solver {
 
@@ -34,12 +37,14 @@ namespace Gahm::Solver {
  * @param isotach_radius radius of the current isotach
  * @param isotach_speed speed of the current isotach
  * @param vmax maximum wind velocity
- * @param fc coriolis force
- * @param bg GAHM Holland B parameter
+ * @param f_coriolis coriolis force
+ * @param gahm_b GAHM Holland B parameter
  */
 GahmRadiusSolver::GahmRadiusSolver(double isotach_radius, double isotach_speed,
-                                   double vmax, double fc, double bg)
-    : m_solver(isotach_radius, isotach_speed, vmax, fc, bg), m_max_it(200) {}
+                                   double vmax, double f_coriolis,
+                                   double gahm_b)
+    : m_solver(isotach_radius, isotach_speed, vmax, f_coriolis, gahm_b),
+      m_max_it(c_max_solver_iterations) {}
 
 /**
  * Runs the solver
@@ -67,11 +72,11 @@ auto GahmRadiusSolver::solve(double lower, double upper, double guess) const
  * iterations
  * @param bg GAHM Holland B
  */
-void GahmRadiusSolver::setBg(double b_gahm) { m_solver.setBg(b_gahm); }
+void GahmRadiusSolver::setGahmB(double gahm_b) { m_solver.setGahmB(gahm_b); }
 
 /**
  * Returns the current GAHM Holland B parameter
  * @return GAHM Holland B
  */
-auto GahmRadiusSolver::bg() const -> double { return m_solver.bg(); }
+auto GahmRadiusSolver::gahm_b() const -> double { return m_solver.gahm_b(); }
 }  // namespace Gahm::Solver

--- a/src/gahm/GahmRadiusSolver.h
+++ b/src/gahm/GahmRadiusSolver.h
@@ -31,11 +31,11 @@ class GahmRadiusSolver {
   GahmRadiusSolver(double isotach_radius, double isotach_speed, double vmax,
                    double fc, double bg);
 
-  [[nodiscard]] double solve(double lower, double upper, double guess) const;
+  [[nodiscard]] auto solve(double lower, double upper, double guess) const -> double;
 
-  void setBg(double bg);
+  void setBg(double gahm_b);
 
-  [[nodiscard]] double bg() const;
+  [[nodiscard]] auto bg() const -> double;
 
  private:
   GahmRadiusSolverPrivate m_solver;

--- a/src/gahm/GahmRadiusSolver.h
+++ b/src/gahm/GahmRadiusSolver.h
@@ -29,13 +29,14 @@ namespace Gahm::Solver {
 class GahmRadiusSolver {
  public:
   GahmRadiusSolver(double isotach_radius, double isotach_speed, double vmax,
-                   double fc, double bg);
+                   double f_coriolis, double gahm_b);
 
-  [[nodiscard]] auto solve(double lower, double upper, double guess) const -> double;
+  [[nodiscard]] auto solve(double lower, double upper, double guess) const
+      -> double;
 
-  void setBg(double gahm_b);
+  void setGahmB(double gahm_b);
 
-  [[nodiscard]] auto bg() const -> double;
+  [[nodiscard]] auto gahm_b() const -> double;
 
  private:
   GahmRadiusSolverPrivate m_solver;

--- a/src/gahm/GahmRadiusSolverPrivate.cpp
+++ b/src/gahm/GahmRadiusSolverPrivate.cpp
@@ -28,13 +28,13 @@ namespace Gahm::Solver {
 
 GahmRadiusSolverPrivate::GahmRadiusSolverPrivate(double isotachRadius,
                                                  double isotachSpeed,
-                                                 double vmax, double fc,
-                                                 double bg)
+                                                 double vmax, double f_coriolis,
+                                                 double gahm_b)
     : m_isotachRadius(isotachRadius),
       m_vmax(vmax),
-      m_fc(fc),
+      m_f_coriolis(f_coriolis),
       m_isotachSpeed(isotachSpeed),
-      m_bg(bg) {}
+      m_gahm_b(gahm_b) {}
 
 /**
  * Function to computeRadiusToMaxWind the Vg function and first derivative for
@@ -45,23 +45,23 @@ GahmRadiusSolverPrivate::GahmRadiusSolverPrivate(double isotachRadius,
 std::pair<double, double> GahmRadiusSolverPrivate::operator()(
     const double &rmax) const {
   const double vg = GahmRadiusSolverPrivate::f(rmax, m_vmax, m_isotachSpeed,
-                                               m_isotachRadius, m_fc, m_bg);
+                                               m_isotachRadius, m_f_coriolis, m_gahm_b);
   const double vgp = GahmRadiusSolverPrivate::f_prime(
-      rmax, m_vmax, m_isotachRadius, m_fc, m_bg);
+      rmax, m_vmax, m_isotachRadius, m_f_coriolis, m_gahm_b);
   return {vg, vgp};
 }
 
 /**
  * Set the GAHM Holland B parameter
- * @param bg GAHM Holland B
+ * @param gahm_b GAHM Holland B
  */
-void GahmRadiusSolverPrivate::setBg(double bg) { m_bg = bg; }
+void GahmRadiusSolverPrivate::setGahmB(double gahm_b) { m_gahm_b = gahm_b; }
 
 /**
  * Returns the solvers current GAHM Holland B
  * @return GAHM B
  */
-double GahmRadiusSolverPrivate::bg() const { return m_bg; }
+double GahmRadiusSolverPrivate::gahm_b() const { return m_gahm_b; }
 
 /**
  * Solves the gahm gradient wind function
@@ -69,15 +69,15 @@ double GahmRadiusSolverPrivate::bg() const { return m_bg; }
  * @param vmax maximum wind speed
  * @param isotach_speed speed of the current isotach
  * @param isotach_radius radius of the current isotach
- * @param fc coriolis force
- * @param bg GAHM Holland B
+ * @param f_coriolis coriolis force
+ * @param gahm_b GAHM Holland B
  * @return Solution to gradient wind
  */
 auto GahmRadiusSolverPrivate::f(double rmax, double vmax, double isotach_speed,
-                                double isotach_radius, double fc, double bg)
+                                double isotach_radius, double f_coriolis, double gahm_b)
     -> double {
   return Gahm::Solver::GahmEquations::GahmFunction(rmax, vmax, isotach_speed,
-                                                   isotach_radius, fc, bg);
+                                                   isotach_radius, f_coriolis, gahm_b);
 }
 
 /**
@@ -85,14 +85,14 @@ auto GahmRadiusSolverPrivate::f(double rmax, double vmax, double isotach_speed,
  * @param rmax Radius to max winds
  * @param vmax Maximum wind speed
  * @param isotach_radius radius of the current isotach
- * @param fc coriolis force
- * @param bg GAHM Holland B parameter
+ * @param f_coriolis coriolis force
+ * @param gahm_b GAHM Holland B parameter
  * @return Solution to first derivative
  */
 auto GahmRadiusSolverPrivate::f_prime(double rmax, double vmax,
-                                      double isotach_radius, double fc,
-                                      double bg) -> double {
+                                      double isotach_radius, double f_coriolis,
+                                      double gahm_b) -> double {
   return Gahm::Solver::GahmEquations::GahmFunctionDerivative(
-      rmax, vmax, isotach_radius, fc, bg);
+      rmax, vmax, isotach_radius, f_coriolis, gahm_b);
 }
 }  // namespace Gahm::Solver

--- a/src/gahm/GahmRadiusSolverPrivate.cpp
+++ b/src/gahm/GahmRadiusSolverPrivate.cpp
@@ -20,6 +20,8 @@
 //
 #include "gahm/GahmRadiusSolverPrivate.h"
 
+#include <utility>
+
 #include "gahm/GahmEquations.h"
 
 namespace Gahm::Solver {
@@ -71,9 +73,9 @@ double GahmRadiusSolverPrivate::bg() const { return m_bg; }
  * @param bg GAHM Holland B
  * @return Solution to gradient wind
  */
-double GahmRadiusSolverPrivate::f(double rmax, double vmax,
-                                  double isotach_speed, double isotach_radius,
-                                  double fc, double bg) {
+auto GahmRadiusSolverPrivate::f(double rmax, double vmax, double isotach_speed,
+                                double isotach_radius, double fc, double bg)
+    -> double {
   return Gahm::Solver::GahmEquations::GahmFunction(rmax, vmax, isotach_speed,
                                                    isotach_radius, fc, bg);
 }
@@ -87,9 +89,9 @@ double GahmRadiusSolverPrivate::f(double rmax, double vmax,
  * @param bg GAHM Holland B parameter
  * @return Solution to first derivative
  */
-double GahmRadiusSolverPrivate::f_prime(double rmax, double vmax,
-                                        double isotach_radius, double fc,
-                                        double bg) {
+auto GahmRadiusSolverPrivate::f_prime(double rmax, double vmax,
+                                      double isotach_radius, double fc,
+                                      double bg) -> double {
   return Gahm::Solver::GahmEquations::GahmFunctionDerivative(
       rmax, vmax, isotach_radius, fc, bg);
 }

--- a/src/gahm/GahmRadiusSolverPrivate.h
+++ b/src/gahm/GahmRadiusSolverPrivate.h
@@ -35,17 +35,17 @@ class GahmRadiusSolverPrivate {
   GahmRadiusSolverPrivate(double isotachRadius, double isotachSpeed,
                           double vmax, double fc, double bg);
 
-  [[nodiscard]] std::pair<double, double> operator()(
-      const double &radiusToMaxWinds) const;
+  [[nodiscard]] auto operator()(const double &radiusToMaxWinds) const
+      -> std::pair<double, double>;
 
   void setBg(double bg);
-  [[nodiscard]] double bg() const;
+  [[nodiscard]] auto bg() const -> double;
 
  private:
-  static double f(double radius_to_max_winds, double vmax, double isotach_speed,
-                  double isotach_radius, double fc, double bg);
-  static double f_prime(double radius_to_max_winds, double vmax,
-                        double isotach_radius, double fc, double bg);
+  static auto f(double radius_to_max_winds, double vmax, double isotach_speed,
+                double isotach_radius, double fc, double bg) -> double;
+  static auto f_prime(double radius_to_max_winds, double vmax,
+                      double isotach_radius, double fc, double bg) -> double;
 
   double m_isotachRadius;
   double m_vmax;

--- a/src/gahm/GahmRadiusSolverPrivate.h
+++ b/src/gahm/GahmRadiusSolverPrivate.h
@@ -33,25 +33,27 @@ namespace Gahm::Solver {
 class GahmRadiusSolverPrivate {
  public:
   GahmRadiusSolverPrivate(double isotachRadius, double isotachSpeed,
-                          double vmax, double fc, double bg);
+                          double vmax, double f_coriolis, double gahm_b);
 
   [[nodiscard]] auto operator()(const double &radiusToMaxWinds) const
       -> std::pair<double, double>;
 
-  void setBg(double bg);
-  [[nodiscard]] auto bg() const -> double;
+  void setGahmB(double gahm_b);
+  [[nodiscard]] auto gahm_b() const -> double;
 
  private:
   static auto f(double radius_to_max_winds, double vmax, double isotach_speed,
-                double isotach_radius, double fc, double bg) -> double;
+                double isotach_radius, double f_coriolis, double gahm_b)
+      -> double;
   static auto f_prime(double radius_to_max_winds, double vmax,
-                      double isotach_radius, double fc, double bg) -> double;
+                      double isotach_radius, double f_coriolis, double gahm_b)
+      -> double;
 
   double m_isotachRadius;
   double m_vmax;
-  double m_fc;
+  double m_f_coriolis;
   double m_isotachSpeed;
-  double m_bg;
+  double m_gahm_b;
 };
 }  // namespace Gahm::Solver
 

--- a/src/gahm/GahmSolver.cpp
+++ b/src/gahm/GahmSolver.cpp
@@ -75,8 +75,8 @@ void GahmSolver::solve() {
     }
     assert(new_rmax > 0.0);
     m_phi = GahmEquations::phi(m_vmax, m_rmax, m_bg, m_fc);
-    m_bg = GahmEquations::bg(m_vmax, m_rmax, m_pc, m_pbk, m_fc, m_phi);
-    if (std::abs(m_bg - m_solver.bg()) < m_bg_tol) {
+    m_bg = GahmEquations::gahm_b(m_vmax, m_rmax, m_pc, m_pbk, m_fc, m_phi);
+    if (std::abs(m_bg - m_solver.gahm_b()) < m_bg_tol) {
       m_it = i;
       break;
     }
@@ -85,10 +85,10 @@ void GahmSolver::solve() {
       throw boost::math::evaluation_error(
           std::string("Solution did not converge."));
     }
-    m_solver.setBg(m_bg);
+    m_solver.setGahmB(m_bg);
   }
   assert(this->rmax() > 0.0);
-  assert(this->bg() > 0.0);
+  assert(this->gahm_b() > 0.0);
 }
 
 /**
@@ -113,19 +113,19 @@ auto GahmSolver::latitude() const -> double { return m_latitude; }
  * Returns the central pressure
  * @return central pressure
  */
-auto GahmSolver::pc() const -> double { return m_pc; }
+auto GahmSolver::p_center() const -> double { return m_pc; }
 
 /**
  * Returns the background pressure
  * @return background pressure
  */
-auto GahmSolver::pbk() const -> double { return m_pbk; }
+auto GahmSolver::p_background() const -> double { return m_pbk; }
 
 /**
  * Returns the coriolis force
  * @return coriolis force
  */
-auto GahmSolver::fc() const -> double { return m_fc; }
+auto GahmSolver::f_coriolis() const -> double { return m_fc; }
 
 /**
  * Returns the maximum wind speed
@@ -151,7 +151,7 @@ auto GahmSolver::rmax() const -> double {
  * solver has not run, the solution is the standard Holland B
  * @return GAHM holland B
  */
-auto GahmSolver::bg() const -> double {
+auto GahmSolver::gahm_b() const -> double {
   if (m_it == 0) {
     throw boost::math::evaluation_error(
         "GAHM Solver ERROR: Solver has not run");

--- a/src/gahm/GahmSolver.cpp
+++ b/src/gahm/GahmSolver.cpp
@@ -21,9 +21,11 @@
 #include "GahmSolver.h"
 
 #include <algorithm>
-#include <cmath>
-#include <stdexcept>
 #include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <string>
 
 #include "boost/math/policies/error_handling.hpp"
 #include "gahm/GahmEquations.h"
@@ -93,52 +95,53 @@ void GahmSolver::solve() {
  * Returns the isotach radius
  * @return isotach radius
  */
-double GahmSolver::isotachRadius() const { return m_isotachRadius; }
+auto GahmSolver::isotachRadius() const -> double { return m_isotachRadius; }
 
 /**
  * Returns the isotach speed
  * @return isotach speed
  */
-double GahmSolver::isotachSpeed() const { return m_isotachSpeed; }
+auto GahmSolver::isotachSpeed() const -> double { return m_isotachSpeed; }
 
 /**
  * Returns the storm latitude
  * @return storm latitude
  */
-double GahmSolver::latitude() const { return m_latitude; }
+auto GahmSolver::latitude() const -> double { return m_latitude; }
 
 /**
  * Returns the central pressure
  * @return central pressure
  */
-double GahmSolver::pc() const { return m_pc; }
+auto GahmSolver::pc() const -> double { return m_pc; }
 
 /**
  * Returns the background pressure
  * @return background pressure
  */
-double GahmSolver::pbk() const { return m_pbk; }
+auto GahmSolver::pbk() const -> double { return m_pbk; }
 
 /**
  * Returns the coriolis force
  * @return coriolis force
  */
-double GahmSolver::fc() const { return m_fc; }
+auto GahmSolver::fc() const -> double { return m_fc; }
 
 /**
  * Returns the maximum wind speed
  * @return maximum wind speed
  */
-double GahmSolver::vmax() const { return m_vmax; }
+auto GahmSolver::vmax() const -> double { return m_vmax; }
 
 /**
  * Returns the solution to the radius to maximum winds. Note that when the
  * solver has not been run, the solution is std::numeric_limits<double>::max()
  * @return radius to maximum winds
  */
-double GahmSolver::rmax() const {
+auto GahmSolver::rmax() const -> double {
   if (m_it == 0) {
-    throw boost::math::evaluation_error("GAHM Solver ERROR: Solver has not run");
+    throw boost::math::evaluation_error(
+        "GAHM Solver ERROR: Solver has not run");
   }
   return m_rmax;
 }
@@ -148,9 +151,10 @@ double GahmSolver::rmax() const {
  * solver has not run, the solution is the standard Holland B
  * @return GAHM holland B
  */
-double GahmSolver::bg() const {
+auto GahmSolver::bg() const -> double {
   if (m_it == 0) {
-    throw boost::math::evaluation_error("GAHM Solver ERROR: Solver has not run");
+    throw boost::math::evaluation_error(
+        "GAHM Solver ERROR: Solver has not run");
   }
   return m_bg;
 }
@@ -159,13 +163,13 @@ double GahmSolver::bg() const {
  * Returns the number of iterations used in the GAHM Holland B solver
  * @return
  */
-size_t GahmSolver::it() const { return m_it; }
+auto GahmSolver::it() const -> size_t { return m_it; }
 
 /*
  * Returns the solution to the GAHM phi parameter. Note that when the
  * solver has not run, the solution is 1.0
  */
-double GahmSolver::phi() const { return m_phi; }
+auto GahmSolver::phi() const -> double { return m_phi; }
 
 /**
  * Estimates the rmax. Used as the initial guess for the solver
@@ -174,8 +178,8 @@ double GahmSolver::phi() const { return m_phi; }
  * @param isorad isotach radius that we are solving for (upper bound)
  * @return estimate of rmax
  */
-double GahmSolver::estimateRmax(const double dp, const double lat,
-                                const double isorad) {
+auto GahmSolver::estimateRmax(const double dp, const double lat,
+                              const double isorad) -> double {
   assert(dp >= 0.0);
   assert(isorad > 0.0);
   auto r1 =

--- a/src/gahm/GahmSolver.h
+++ b/src/gahm/GahmSolver.h
@@ -21,8 +21,9 @@
 #ifndef GAHM_SRC_GAHMSOLVER_H_
 #define GAHM_SRC_GAHMSOLVER_H_
 
+#include <cstddef>
+
 #include "gahm/GahmRadiusSolver.h"
-#include "physical/Constants.h"
 
 namespace Gahm::Solver {
 
@@ -33,30 +34,30 @@ class GahmSolver {
 
   void solve();
 
-  [[nodiscard]] double isotachRadius() const;
+  [[nodiscard]] auto isotachRadius() const -> double;
 
-  [[nodiscard]] double isotachSpeed() const;
+  [[nodiscard]] auto isotachSpeed() const -> double;
 
-  [[nodiscard]] double latitude() const;
+  [[nodiscard]] auto latitude() const -> double;
 
-  [[nodiscard]] double pc() const;
+  [[nodiscard]] auto pc() const -> double;
 
-  [[nodiscard]] double pbk() const;
+  [[nodiscard]] auto pbk() const -> double;
 
-  [[nodiscard]] double fc() const;
+  [[nodiscard]] auto fc() const -> double;
 
-  [[nodiscard]] double vmax() const;
+  [[nodiscard]] auto vmax() const -> double;
 
-  [[nodiscard]] double rmax() const;
+  [[nodiscard]] auto rmax() const -> double;
 
-  [[nodiscard]] double bg() const;
+  [[nodiscard]] auto bg() const -> double;
 
-  [[nodiscard]] double phi() const;
+  [[nodiscard]] auto phi() const -> double;
 
-  [[nodiscard]] size_t it() const;
+  [[nodiscard]] auto it() const -> size_t;
 
  private:
-  static double estimateRmax(double dp, double lat, double isorad);
+  static auto estimateRmax(double dp, double lat, double isorad) -> double;
 
   double m_isotachRadius;
   double m_isotachSpeed;

--- a/src/gahm/GahmSolver.h
+++ b/src/gahm/GahmSolver.h
@@ -40,17 +40,17 @@ class GahmSolver {
 
   [[nodiscard]] auto latitude() const -> double;
 
-  [[nodiscard]] auto pc() const -> double;
+  [[nodiscard]] auto p_center() const -> double;
 
-  [[nodiscard]] auto pbk() const -> double;
+  [[nodiscard]] auto p_background() const -> double;
 
-  [[nodiscard]] auto fc() const -> double;
+  [[nodiscard]] auto f_coriolis() const -> double;
 
   [[nodiscard]] auto vmax() const -> double;
 
   [[nodiscard]] auto rmax() const -> double;
 
-  [[nodiscard]] auto bg() const -> double;
+  [[nodiscard]] auto gahm_b() const -> double;
 
   [[nodiscard]] auto phi() const -> double;
 

--- a/src/output/OutputFile.h
+++ b/src/output/OutputFile.h
@@ -44,8 +44,8 @@ class OutputFile {
              const Gahm::Datatypes::WindGrid &wind_grid)
       : m_start_date(start_date),
         m_end_date(end_date),
-        m_filename(std::move(filename)),
-        m_wind_grid(wind_grid) {}
+        m_wind_grid(wind_grid),
+        m_filename(std::move(filename)){}
 
   virtual ~OutputFile() = default;
 

--- a/src/output/OutputFile.h
+++ b/src/output/OutputFile.h
@@ -56,14 +56,18 @@ class OutputFile {
   virtual void write(const Datatypes::Date &date,
                      Gahm::Datatypes::VortexSolution &solution) = 0;
 
-  NODISCARD std::string filename() const { return m_filename; }
+  NODISCARD auto filename() const -> std::string { return m_filename; }
 
   NODISCARD const Gahm::Datatypes::WindGrid &windGrid() const {
     return m_wind_grid;
   }
 
-  NODISCARD Gahm::Datatypes::Date start_date() const { return m_start_date; }
-  NODISCARD Gahm::Datatypes::Date end_date() const { return m_end_date; }
+  NODISCARD auto start_date() const -> Gahm::Datatypes::Date {
+    return m_start_date;
+  }
+  NODISCARD auto end_date() const -> Gahm::Datatypes::Date {
+    return m_end_date;
+  }
 
  private:
   Datatypes::Date m_start_date;

--- a/src/physical/Atmospheric.h
+++ b/src/physical/Atmospheric.h
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cmath>
 
+#include "math.h"
 #include "physical/Constants.h"
 
 namespace Gahm::Physical::Atmospheric {
@@ -31,29 +32,30 @@ namespace Gahm::Physical::Atmospheric {
 /**
  * Computes the traditional Holland B parameter
  * @param vmax maximum storm wind velocity
- * @param p0 minimum storm pressure
- * @param pinf background pressure
+ * @param p_center minimum storm pressure
+ * @param p_background background pressure
  * @return Holland B
  */
-constexpr double calcHollandB(const double vmax, const double p0,
-                              const double pinf) {
-  assert(p0 != pinf);
+constexpr auto calcHollandB(const double vmax, const double p_center,
+                            const double p_background) -> double {
+  assert(p_center != p_background);
   return (vmax * vmax * Gahm::Physical::Constants::rhoAir() * M_E) /
-         (pinf - p0);
+         (p_background - p_center);
 }
 
 /**
  * Computes the Rossby number for the storm
  * @param vmax max storm wind velocity
  * @param rmax radius to max winds
- * @param fc coriolis force
+ * @param f_coriolis coriolis force
  * @return rossby number
  */
-constexpr double rossbyNumber(double vmax, double rmax, double fc) {
-  assert(fc > 0.0);
+constexpr auto rossbyNumber(double vmax, double rmax, double f_coriolis)
+    -> double {
+  assert(f_coriolis > 0.0);
   assert(rmax > 0.0);
   assert(vmax > 0.0);
-  return vmax / (fc * rmax);
+  return vmax / (f_coriolis * rmax);
 }
 
 /**
@@ -62,7 +64,7 @@ constexpr double rossbyNumber(double vmax, double rmax, double fc) {
  * @param rmx radius to maximum winds
  * @return inflow angle
  */
-constexpr double queenslandInflowAngle(double r, double rmx) noexcept {
+constexpr auto queenslandInflowAngle(double r, double rmx) noexcept -> double {
   constexpr double degree1 = Constants::deg2rad();
   constexpr double degree10 = 10.0 * Constants::deg2rad();
   constexpr double degree25 = 25.0 * Constants::deg2rad();

--- a/src/physical/Constants.h
+++ b/src/physical/Constants.h
@@ -29,55 +29,55 @@ namespace Gahm::Physical::Constants {
  * Pi constant
  * @return Pi constant
  */
-static constexpr double pi() { return M_PI; }
+static constexpr auto pi() -> double { return M_PI; }
 
 /*
  * 2*Pi constant
  * @return 2*Pi constant
  */
-static constexpr double twoPi() { return 2.0 * M_PI; }
+static constexpr auto twoPi() -> double { return 2.0 * M_PI; }
 
 /*
  * Pi/2 constant
  * @return Pi/2 constant
  */
-static constexpr double halfPi() { return M_PI_2; }
+static constexpr auto halfPi() -> double { return M_PI_2; }
 
 /*
  * Pi/4 constant
  * @return Pi/4 constant
  */
-static constexpr double quarterPi() { return M_PI_4; }
+static constexpr auto quarterPi() -> double { return M_PI_4; }
 
 /*
  * Pi/180 constant
  * @return Pi/180 constant
  */
-static constexpr double deg2rad() { return M_PI / 180.0; }
+static constexpr auto deg2rad() -> double { return M_PI / 180.0; }
 
 /*
  * 180/Pi constant
  * @return 180/Pi constant
  */
-static constexpr double rad2deg() { return 180.0 / M_PI; }
+static constexpr auto rad2deg() -> double { return 180.0 / M_PI; }
 
 /*
  * Background pressure in millibars
  * @return Background pressure in millibars
  */
-static constexpr double backgroundPressure() { return 1013.00; }
+static constexpr auto backgroundPressure() -> double { return 1013.00; }
 
 /*
  * Wind speed reduction factor for boundary layer winds to 10m
  * @return Wind speed reduction factor for 10m winds
  */
-static constexpr double topOfBoundaryLayerToTenMeter() { return 0.9; }
+static constexpr auto topOfBoundaryLayerToTenMeter() -> double { return 0.9; }
 
 /*
  * Wind speed increase factor for 10m winds to top of boundary layer
  * @return Wind speed increase factor for 10m winds to top of boundary layer
  */
-static constexpr double tenMeterToTopOfBoundaryLayer() {
+static constexpr auto tenMeterToTopOfBoundaryLayer() -> double {
   return 1.0 / topOfBoundaryLayerToTenMeter();
 }
 
@@ -85,25 +85,25 @@ static constexpr double tenMeterToTopOfBoundaryLayer() {
  * Rho of air in kg/m^3
  * @return Rho of air in kg/m^3
  */
-static constexpr double rhoAir() { return 1.293; }
+static constexpr auto rhoAir() -> double { return 1.293; }
 
 /*
  * Gravitational acceleration in m/s^2
  * @return Gravitational acceleration in m/s^2
  */
-static constexpr double g() { return 9.80665; }
+static constexpr auto g() -> double { return 9.80665; }
 
 /*
  * Rho of water in kg/m^3
  * @return Rho of water in kg/m^3
  */
-static constexpr double rhoWater() { return 1000.0; }
+static constexpr auto rhoWater() -> double { return 1000.0; }
 
 /*
  * One to ten conversion factor
  * @return One to ten conversion factor
  */
-static constexpr double oneMinuteToTenMinuteWind() { return 0.8928; }
+static constexpr auto oneMinuteToTenMinuteWind() -> double { return 0.8928; }
 
 }  // namespace Gahm::Physical::Constants
 

--- a/src/physical/Earth.h
+++ b/src/physical/Earth.h
@@ -22,6 +22,7 @@
 #define GAHM_SRC_EARTH_H_
 
 #include <cmath>
+#include <limits>
 #include <tuple>
 
 #include "datatypes/Point.h"
@@ -34,13 +35,13 @@ namespace Gahm::Physical::Earth {
  * Rotational rate of the earth in radians/s
  * @return Rotational rate of the earth in radians/s
  */
-constexpr double omega() { return 7.292115e-5; }
+constexpr auto omega() -> double { return 7.292115e-5; }
 
 /*
  * Earth's angular velocity in radians per second
  * @return Earth's angular velocity in radians per second
  */
-static double coriolis(const double lat) {
+static auto coriolis(const double lat) -> double {
   return 2.0 * omega() * std::sin(lat * Gahm::Physical::Constants::deg2rad());
 }
 
@@ -48,13 +49,13 @@ static double coriolis(const double lat) {
  * Earth equatorial radius in meters
  * @return Earth equatorial radius in meters
  */
-constexpr double equatorialRadius() { return 6378137.0; }
+constexpr auto equatorialRadius() -> double { return 6378137.0; }
 
 /*
  * Earth polar radius in meters
  * @return Earth polar radius in meters
  */
-constexpr double polarRadius() { return 6356752.3; }
+constexpr auto polarRadius() -> double { return 6356752.3; }
 
 /*
  * Earth radius in meters at a given latitude
@@ -65,15 +66,20 @@ constexpr double polarRadius() { return 6356752.3; }
  * @param latitude Latitude in degrees
  * @return Earth radius in meters
  */
-static double radius(
-    const double latitude = std::numeric_limits<double>::max()) {
-  if (latitude == std::numeric_limits<double>::max()) return equatorialRadius();
-  const double l = Gahm::Physical::Constants::deg2rad() * latitude;
-  return std::sqrt(
-      (std::pow(equatorialRadius(), 4.0) * std::cos(l) * std::cos(l) +
-       std::pow(polarRadius(), 4.0) * std::sin(l) * std::sin(l)) /
-      (std::pow(equatorialRadius(), 2.0) * std::cos(l) * std::cos(l) +
-       std::pow(polarRadius(), 2.0) * std::sin(l) * std::sin(l)));
+static auto radius(const double latitude = std::numeric_limits<double>::max())
+    -> double {
+  if (latitude == std::numeric_limits<double>::max()) {
+    return equatorialRadius();
+  }
+  const double lat_radians = Gahm::Physical::Constants::deg2rad() * latitude;
+  return std::sqrt((std::pow(equatorialRadius(), 4.0) * std::cos(lat_radians) *
+                        std::cos(lat_radians) +
+                    std::pow(polarRadius(), 4.0) * std::sin(lat_radians) *
+                        std::sin(lat_radians)) /
+                   (std::pow(equatorialRadius(), 2.0) * std::cos(lat_radians) *
+                        std::cos(lat_radians) +
+                    std::pow(polarRadius(), 2.0) * std::sin(lat_radians) *
+                        std::sin(lat_radians)));
 }
 
 /*
@@ -84,7 +90,7 @@ static double radius(
  * @param y2 Latitude 2 in degrees
  * @return Earth radius in meters
  */
-static double radius(const double y1, const double y2) {
+static auto radius(const double y1, const double y2) -> double {
   return Earth::radius((y1 + y2) / 2.0);
 }
 
@@ -96,8 +102,8 @@ static double radius(const double y1, const double y2) {
  * @param y2 Latitude 2 in degrees
  * @return Distance between two points on the earth's surface in meters
  */
-static double distance(const double x1, const double y1, const double x2,
-                       const double y2) {
+static auto distance(const double x1, const double y1, const double x2,
+                     const double y2) -> double {
   constexpr double deg2rad = Units::convert(Units::Degree, Units::Radian);
   const double lat1 = deg2rad * y1;
   const double lon1 = deg2rad * x1;
@@ -117,8 +123,8 @@ static double distance(const double x1, const double y1, const double x2,
  * @param p1 Point 1
  * @return Distance between two points on the earth's surface in meters
  */
-static double distance(const Gahm::Datatypes::Point &p0,
-                       const Gahm::Datatypes::Point &p1) {
+static auto distance(const Gahm::Datatypes::Point &p0,
+                     const Gahm::Datatypes::Point &p1) -> double {
   return distance(p0.x(), p0.y(), p1.x(), p1.y());
 }
 
@@ -130,16 +136,18 @@ static double distance(const Gahm::Datatypes::Point &p0,
  * @param y2 Latitude 2 in degrees
  * @return Azimuth between two points on the earth's surface in meters
  */
-static double azimuth(double x1, double y1, double x2, double y2) {
+static auto azimuth(double x1, double y1, double x2, double y2) -> double {
   constexpr double deg2rad = Units::convert(Units::Degree, Units::Radian);
-  double dx = (x2 - x1) * deg2rad;
-  auto phi1 = y1 * deg2rad;
-  auto phi2 = y2 * deg2rad;
-  auto ay = std::sin(dx) * std::cos(phi2);
-  auto ax = std::cos(phi1) * std::sin(phi2) -
-            std::sin(phi1) * std::cos(phi2) * std::cos(dx);
+  const double dx = (x2 - x1) * deg2rad;
+  const double phi1 = y1 * deg2rad;
+  const double phi2 = y2 * deg2rad;
+  const double ay = std::sin(dx) * std::cos(phi2);
+  const double ax = std::cos(phi1) * std::sin(phi2) -
+                    std::sin(phi1) * std::cos(phi2) * std::cos(dx);
   auto azi = std::atan2(-ay, -ax);
-  if (azi < 0.0) azi += Physical::Constants::twoPi();
+  if (azi < 0.0) {
+    azi += Physical::Constants::twoPi();
+  }
   return azi;
 }
 
@@ -149,8 +157,8 @@ static double azimuth(double x1, double y1, double x2, double y2) {
  * @param p1 Point 1
  * @return Azimuth between two points on the earth's surface in meters
  */
-static double azimuth(const Gahm::Datatypes::Point &p0,
-                      const Gahm::Datatypes::Point &p1) {
+static auto azimuth(const Gahm::Datatypes::Point &p0,
+                    const Gahm::Datatypes::Point &p1) -> double {
   return azimuth(p0.x(), p0.y(), p1.x(), p1.y());
 }
 
@@ -163,12 +171,10 @@ static double azimuth(const Gahm::Datatypes::Point &p0,
  * @param y2 Latitude 2 in degrees
  * @return Tuple of distances between the two points and the midpoint
  */
-static std::tuple<double, double, double> sphericalDx(const double x1,
-                                                      const double y1,
-                                                      const double x2,
-                                                      const double y2) {
-  double meanx = (x1 + x2) / 2.0;
-  double meany = (y1 + y2) / 2.0;
+static auto sphericalDx(const double x1, const double y1, const double x2,
+                        const double y2) -> std::tuple<double, double, double> {
+  const double meanx = (x1 + x2) / 2.0;
+  const double meany = (y1 + y2) / 2.0;
   return std::make_tuple(Gahm::Physical::Earth::distance(x1, meany, x2, meany),
                          Gahm::Physical::Earth::distance(meanx, y1, meanx, y2),
                          Gahm::Physical::Earth::distance(x1, y1, x2, y2));

--- a/src/physical/Units.h
+++ b/src/physical/Units.h
@@ -29,7 +29,7 @@ namespace Gahm::Physical::Units {
 enum AngleNormalizationType { ZERO_TO_360, NEG_180_TO_180 };
 
 template <typename T, AngleNormalizationType AngleType>
-constexpr T normalizeAngle(const T &angle) noexcept {
+constexpr auto normalizeAngle(const T &angle) noexcept -> T {
   if (AngleType == ZERO_TO_360) {
     if (angle < 0.0) {
       return angle + Physical::Constants::twoPi();
@@ -59,7 +59,7 @@ class UnitInternal {
     constexpr auto operator()() const { return m_value; }
 
    private:
-    const double m_value;
+    double m_value;
   };
 
   class Length : public UnitType {
@@ -102,11 +102,11 @@ constexpr UnitInternal::Pressure Pascal(100000.0);
 constexpr UnitInternal::Pressure Bar(1.0);
 constexpr UnitInternal::Pressure MetersH20(10.197442889221);
 
-template <typename T,
-          std::enable_if_t<std::is_base_of<UnitInternal::UnitType, T>::value,
-                           bool> = true>
-constexpr double convert(const T &a, const T &b) {
-  return b() / a();
+template <
+    typename T,
+    std::enable_if_t<std::is_base_of_v<UnitInternal::UnitType, T>, bool> = true>
+constexpr auto convert(const T &lhs, const T &rhs) -> double {
+  return rhs() / lhs();
 }
 
 };  // namespace Gahm::Physical::Units

--- a/src/preprocessor/Preprocessor.cpp
+++ b/src/preprocessor/Preprocessor.cpp
@@ -84,7 +84,7 @@ void Preprocessor::solve() {
                                         p_min, p_back, latitude);
         solver.solve();
         quadrant.setRadiusToMaxWindSpeed(solver.rmax());
-        quadrant.setGahmHollandB(solver.bg());
+        quadrant.setGahmHollandB(solver.gahm_b());
       }
     }
   }

--- a/src/preprocessor/Preprocessor.cpp
+++ b/src/preprocessor/Preprocessor.cpp
@@ -286,6 +286,11 @@ auto Preprocessor::removeTranslationVelocity(
   //      wind_speed, Atcf::AtcfQuadrant::quadrant_angle(quadrant), latitude);
   //  auto [tsx, tsy] = Vortex::computeTranslationVelocityComponents(
   //      wind_speed, vmax_10m, transit);
+  // Mark parameters used to suppress warnings
+  (void)vmax_10m;
+  (void)latitude;
+  (void)quadrant;
+  (void)transit;
 
   return wind_speed;
   // return std::sqrt(std::pow(uu - tsx, 2.0) + std::pow(vv - tsy, 2.0));

--- a/src/preprocessor/Preprocessor.h
+++ b/src/preprocessor/Preprocessor.h
@@ -22,7 +22,9 @@
 #define GAHM_SRC_PREPROCESSOR_PREPROCESSOR_H_
 
 #include "atcf/AtcfFile.h"
+#include "atcf/AtcfIsotach.h"
 #include "atcf/AtcfQuadrant.h"
+#include "atcf/AtcfSnap.h"
 #include "atcf/StormTranslation.h"
 
 namespace Gahm {
@@ -40,16 +42,25 @@ class Preprocessor {
   void fillMissingAtcfData();
   void computeStormTranslationVelocities();
   void computeBoundaryLayerWindspeed();
-  static Gahm::Atcf::StormTranslation getTranslation(
-      const Gahm::Atcf::AtcfSnap &now, const Gahm::Atcf::AtcfSnap &next);
+  static auto getTranslation(const Gahm::Atcf::AtcfSnap &now,
+                             const Gahm::Atcf::AtcfSnap &next)
+      -> Gahm::Atcf::StormTranslation;
 
-  static double removeTranslationVelocity(double wind_speed, double vmax_10m,
-                                          int quadrant,
-                                          const Atcf::StormTranslation &transit,
-                                          double latitude);
-  static double removeTranslationVelocity(
-      double wind_speed, double vmax_10m,
-      const Atcf::StormTranslation &transit);
+  static auto removeTranslationVelocity(double wind_speed, double vmax_10m,
+                                        int quadrant,
+                                        const Atcf::StormTranslation &transit,
+                                        double latitude) -> double;
+  static auto removeTranslationVelocity(double wind_speed, double vmax_10m,
+                                        const Atcf::StormTranslation &transit)
+      -> double;
+
+  static void computeSingleMissingIsotachRadius(
+      Gahm::Atcf::AtcfIsotach &isotach);
+  static void computeTwoMissingIsotachRadii(Gahm::Atcf::AtcfIsotach &isotach);
+  static void ComputeThreeMissingIsotachRadii(Gahm::Atcf::AtcfIsotach &isotach);
+  static void setAllIsotachRadiiToRmax(const Gahm::Atcf::AtcfSnap &snap,
+                                       Gahm::Atcf::AtcfIsotach &isotach);
+  static auto countMissingIsotachRadii(Atcf::AtcfIsotach &isotach) -> long;
 
   Gahm::Atcf::AtcfFile *m_atcf{nullptr};
   bool m_isotachsProcessed;

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(SWIG REQUIRED)
+find_package(SWIG 4.0 REQUIRED)
 find_package(
   Python3
   COMPONENTS Interpreter Development.Module

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(pygahm SHARED
             ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/python_gahm_wrap.cxx)
 target_include_directories(pygahm PRIVATE ${Python3_INCLUDE_DIRS}
                                           ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(pygahm gahm_objectlib)
+target_link_libraries(pygahm gahm_objectlib gahm_interface)
 
 if(APPLE)
   target_link_libraries(pygahm Python3::Module)
@@ -37,7 +37,7 @@ set_property(
   PROPERTY ADDITIONAL_MAKE_CLEAN_FILES pygahm.py
            CMakeFiles/python_gahm_wrap.cxx)
 
-add_dependencies(pygahm gahm_objectlib)
+add_dependencies(pygahm gahm_objectlib gahm_interface)
 
 if(PYTHON_PACKAGE_BUILD)
   set_target_properties(pygahm PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/src/swig/CMakeLists.txt
+++ b/src/swig/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(pygahm SHARED
             ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/python_gahm_wrap.cxx)
 target_include_directories(pygahm PRIVATE ${Python3_INCLUDE_DIRS}
                                           ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(pygahm gahm_static)
+target_link_libraries(pygahm gahm_objectlib)
 
 if(APPLE)
   target_link_libraries(pygahm Python3::Module)
@@ -37,7 +37,7 @@ set_property(
   PROPERTY ADDITIONAL_MAKE_CLEAN_FILES pygahm.py
            CMakeFiles/python_gahm_wrap.cxx)
 
-add_dependencies(pygahm gahm_static)
+add_dependencies(pygahm gahm_objectlib)
 
 if(PYTHON_PACKAGE_BUILD)
   set_target_properties(pygahm PROPERTIES LIBRARY_OUTPUT_DIRECTORY

--- a/src/util/Interpolation.h
+++ b/src/util/Interpolation.h
@@ -32,12 +32,12 @@ namespace Gahm::Interpolation {
  * @param weight Weight
  * @return Linearly interpolated value
  */
-constexpr double linear(double v0, double v1, double weight) noexcept {
+constexpr auto linear(double v0, double v1, double weight) noexcept -> double {
   return (v0 * (1.0 - weight)) + (v1 * weight);
 }
 
-constexpr double angle(double v0, double v1, double weight,
-                       bool wrap = false) noexcept {
+constexpr auto angle(double v0, double v1, double weight,
+                       bool wrap = false) noexcept -> double {
   if (wrap && v1 < v0) v1 += Gahm::Physical::Constants::twoPi();
   auto angle = linear(v0, v1, weight);
   if (angle < 0.0) {
@@ -48,18 +48,17 @@ constexpr double angle(double v0, double v1, double weight,
   return angle;
 }
 
-constexpr double angle_idw(double v0, double v1, double delta_angle) noexcept {
-  constexpr double angle_1 = Gahm::Physical::Constants::deg2rad();
-  constexpr double angle_89 = 89.0 * angle_1;
-  constexpr double angle_90 = 90.0 * angle_1;
-  if (delta_angle < angle_1) {
+constexpr auto angle_idw(double v0, double v1, double delta_angle) noexcept -> double {
+  constexpr auto angle_89 = 89.0 * Gahm::Physical::Constants::deg2rad();
+  constexpr auto angle_90 = 90.0 * Gahm::Physical::Constants::deg2rad();
+  if (delta_angle < Gahm::Physical::Constants::deg2rad()) {
     return v0;
   } else if (delta_angle > angle_89) {
     return v1;
   } else {
-    double num = v0 / std::pow(delta_angle, 2.0) +
+    const double num = v0 / std::pow(delta_angle, 2.0) +
                  v1 / std::pow(angle_90 - delta_angle, 2.0);
-    double den = 1.0 / std::pow(delta_angle, 2.0) +
+    const double den = 1.0 / std::pow(delta_angle, 2.0) +
                  1.0 / std::pow(angle_90 - delta_angle, 2.0);
     return num / den;
   }

--- a/src/util/StringUtilities.h
+++ b/src/util/StringUtilities.h
@@ -22,23 +22,39 @@
 #define GAHM_SRC_UTIL_STRINGUTILITIES_H_
 
 #include <string>
+#include <type_traits>
 #include <vector>
 
+#include "boost/algorithm/string/classification.hpp"
+#include "boost/algorithm/string/constants.hpp"
 #include "boost/algorithm/string/split.hpp"
 #include "boost/algorithm/string/trim.hpp"
 
 namespace Gahm::detail::Utilities {
-std::vector<std::string> splitString(const std::string &s) {
-  const auto s2 = boost::trim_copy_if(s, boost::is_any_of(" "));
+
+/**
+ * @brief Split a string by commas
+ * @param string_value string to split
+ * @return vector of strings
+ */
+auto splitString(const std::string &string_value) -> std::vector<std::string> {
+  const auto sanitized_string =
+      boost::trim_copy_if(string_value, boost::is_any_of(" "));
   std::vector<std::string> results;
-  boost::algorithm::split(results, s2, boost::is_any_of(","),
+  boost::algorithm::split(results, sanitized_string, boost::is_any_of(","),
                           boost::token_compress_off);
   return results;
 }
 
+/**
+ * @brief Read a value from a string and check if it is blank
+ * @tparam T Type of value to read
+ * @param s String to read
+ * @return Value or 0 if blank
+ */
 template <typename T,
-          typename = typename std::enable_if<std::is_fundamental_v<T>>::type>
-T readValueCheckBlank(const std::string &s) {
+          typename = typename std::enable_if_t<std::is_fundamental_v<T>>>
+auto readValueCheckBlank(const std::string &s) -> T {
   const auto s_copy = boost::trim_copy(s);
   if (s_copy.empty()) {
     return 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,16 +92,17 @@ foreach(test ${TestList})
 
   if(GAHM_ENABLE_COVERAGE)
     set_target_properties(
-            ${test_name} PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
-            LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
+      ${test_name} PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
+                              LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
   endif()
 
-  target_link_libraries(${test_name} PRIVATE gahm_static Catch2::Catch2WithMain
+  target_link_libraries(${test_name} PRIVATE Catch2::Catch2WithMain
                                              OpenSSL::SSL)
   set_target_properties(
     ${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                             ${CMAKE_CURRENT_BINARY_DIR}/tests)
-  add_dependencies(${test_name} gahm_static)
+  target_link_libraries(${test_name} PRIVATE gahm_objectlib gahm_interface)
+  add_dependencies(${test_name} gahm_objectlib gahm_interface)
 endforeach()
 # ##############################################################################
 
@@ -122,15 +123,16 @@ if(GAHM_ENABLE_FORTRAN)
 
     if(GAHM_ENABLE_COVERAGE)
       set_target_properties(
-              ${test_name} PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
-              LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
+        ${test_name} PROPERTIES COMPILE_FLAGS ${GAHM_COVERAGE_COMPILE_FLAGS}
+                                LINK_FLAGS ${GAHM_COVERAGE_LINK_FLAGS})
     endif()
 
-    target_link_libraries(${test_name} PRIVATE gahm_static)
     set_target_properties(
       ${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                               ${CMAKE_CURRENT_BINARY_DIR}/tests)
-    add_dependencies(${test_name} gahm_static)
+
+    target_link_libraries(${test_name} PRIVATE gahm_objectlib gahm_fortran gahm_interface)
+    add_dependencies(${test_name} gahm_objectlib gahm_fortran gahm_interface)
   endforeach()
 endif()
 # ##############################################################################

--- a/tests/cxx_tests/TEST_Preprocessor.cpp
+++ b/tests/cxx_tests/TEST_Preprocessor.cpp
@@ -64,7 +64,7 @@ TEST_CASE("GahmSolver", "[Preprocessor]") {
       isorad[0], isospd[0], vmax[0], p0, pinf, latitude);
   solver->solve();
   double solution_rmax = solver->rmax();
-  double solution_b = solver->bg();
+  double solution_b = solver->gahm_b();
 
   REQUIRE(solution_rmax / nmi2m ==
           Catch::Approx(39.5956715406));  // Solution checked in nmi

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(test ${FuzzList})
                              ${Boost_INCLUDE_DIRS}
   )
   target_link_libraries(
-    ${test_name} PRIVATE gahm_static project_options project_warnings -coverage
+    ${test_name} PRIVATE gahm_objectlib gahm_interface project_options project_warnings -coverage
                          -fsanitize=fuzzer,undefined,address)
   target_compile_options(${test_name}
                          PRIVATE -fsanitize=fuzzer,undefined,address)
@@ -33,5 +33,5 @@ foreach(test ${FuzzList})
   set_target_properties(
     ${test_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                             ${CMAKE_CURRENT_BINARY_DIR}/fuzz)
-  add_dependencies(${test_name} gahm_static)
+  add_dependencies(${test_name} gahm_objectlib gahm_interface)
 endforeach()

--- a/thirdparty/date_hh/date.hpp
+++ b/thirdparty/date_hh/date.hpp
@@ -17,8 +17,8 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -28,20 +28,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-// Our apologies.  When the previous paragraph was written, lowercase had not
-// yet been invented (that would involve another several millennia of
-// evolution). We did not mean to shout.
+// Our apologies.  When the previous paragraph was written, lowercase had not yet
+// been invented (that would involve another several millennia of evolution).
+// We did not mean to shout.
 
 #ifndef HAS_STRING_VIEW
-#if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define HAS_STRING_VIEW 1
-#else
-#define HAS_STRING_VIEW 0
-#endif
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#    define HAS_STRING_VIEW 1
+#  else
+#    define HAS_STRING_VIEW 0
+#  endif
 #endif  // HAS_STRING_VIEW
 
-#include <algorithm>
 #include <cassert>
+#include <algorithm>
 #include <cctype>
 #include <chrono>
 #include <climits>
@@ -62,97 +62,98 @@
 #include <stdexcept>
 #include <string>
 #if HAS_STRING_VIEW
-#include <string_view>
+# include <string_view>
 #endif
-#include <type_traits>
 #include <utility>
+#include <type_traits>
 
 #ifdef __GNUC__
-#pragma GCC diagnostic push
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
-#pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-#if __GNUC__ < 5
-// GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
-#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#endif
+# pragma GCC diagnostic push
+# if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
+#  pragma GCC diagnostic ignored "-Wpedantic"
+# endif
+# if __GNUC__ < 5
+   // GCC 4.9 Bug 61489 Wrong warning with -Wmissing-field-initializers
+#  pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+# endif
 #endif
 
 #ifdef _MSC_VER
-#pragma warning(push)
+#   pragma warning(push)
 // warning C4127: conditional expression is constant
-#pragma warning(disable : 4127)
+#   pragma warning(disable : 4127)
 #endif
 
-namespace date {
+namespace date
+{
 
 //---------------+
 // Configuration |
 //---------------+
 
 #ifndef ONLY_C_LOCALE
-#define ONLY_C_LOCALE 0
+#  define ONLY_C_LOCALE 0
 #endif
 
 #if defined(_MSC_VER) && (!defined(__clang__) || (_MSC_VER < 1910))
 // MSVC
-#ifndef _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
-#define _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
-#endif
-#if _MSC_VER < 1910
+#  ifndef _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
+#    define _SILENCE_CXX17_UNCAUGHT_EXCEPTION_DEPRECATION_WARNING
+#  endif
+#  if _MSC_VER < 1910
 //   before VS2017
-#define CONSTDATA const
-#define CONSTCD11
-#define CONSTCD14
-#define NOEXCEPT _NOEXCEPT
-#else
+#    define CONSTDATA const
+#    define CONSTCD11
+#    define CONSTCD14
+#    define NOEXCEPT _NOEXCEPT
+#  else
 //   VS2017 and later
-#define CONSTDATA constexpr const
-#define CONSTCD11 constexpr
-#define CONSTCD14 constexpr
-#define NOEXCEPT noexcept
-#endif
+#    define CONSTDATA constexpr const
+#    define CONSTCD11 constexpr
+#    define CONSTCD14 constexpr
+#    define NOEXCEPT noexcept
+#  endif
 
 #elif defined(__SUNPRO_CC) && __SUNPRO_CC <= 0x5150
 // Oracle Developer Studio 12.6 and earlier
-#define CONSTDATA constexpr const
-#define CONSTCD11 constexpr
-#define CONSTCD14
-#define NOEXCEPT noexcept
+#  define CONSTDATA constexpr const
+#  define CONSTCD11 constexpr
+#  define CONSTCD14
+#  define NOEXCEPT noexcept
 
 #elif __cplusplus >= 201402
 // C++14
-#define CONSTDATA constexpr const
-#define CONSTCD11 constexpr
-#define CONSTCD14 constexpr
-#define NOEXCEPT noexcept
+#  define CONSTDATA constexpr const
+#  define CONSTCD11 constexpr
+#  define CONSTCD14 constexpr
+#  define NOEXCEPT noexcept
 #else
 // C++11
-#define CONSTDATA constexpr const
-#define CONSTCD11 constexpr
-#define CONSTCD14
-#define NOEXCEPT noexcept
+#  define CONSTDATA constexpr const
+#  define CONSTCD11 constexpr
+#  define CONSTCD14
+#  define NOEXCEPT noexcept
 #endif
 
 #ifndef HAS_UNCAUGHT_EXCEPTIONS
-#if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define HAS_UNCAUGHT_EXCEPTIONS 1
-#else
-#define HAS_UNCAUGHT_EXCEPTIONS 0
-#endif
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#    define HAS_UNCAUGHT_EXCEPTIONS 1
+#  else
+#    define HAS_UNCAUGHT_EXCEPTIONS 0
+#  endif
 #endif  // HAS_UNCAUGHT_EXCEPTIONS
 
 #ifndef HAS_VOID_T
-#if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
-#define HAS_VOID_T 1
-#else
-#define HAS_VOID_T 0
-#endif
+#  if __cplusplus >= 201703 || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
+#    define HAS_VOID_T 1
+#  else
+#    define HAS_VOID_T 0
+#  endif
 #endif  // HAS_VOID_T
 
 // Protect from Oracle sun macro
 #ifdef sun
-#undef sun
+#  undef sun
 #endif
 
 // Work around for a NVCC compiler bug which causes it to fail
@@ -172,40 +173,39 @@ using ratio_divide = decltype(std::ratio_divide<R1, R2>{});
 
 // durations
 
-using days = std::chrono::duration<
-    int, detail::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
+using days = std::chrono::duration
+    <int, detail::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
 
-using weeks =
-    std::chrono::duration<int,
-                          detail::ratio_multiply<std::ratio<7>, days::period>>;
+using weeks = std::chrono::duration
+    <int, detail::ratio_multiply<std::ratio<7>, days::period>>;
 
-using years = std::chrono::duration<
-    int, detail::ratio_multiply<std::ratio<146097, 400>, days::period>>;
+using years = std::chrono::duration
+    <int, detail::ratio_multiply<std::ratio<146097, 400>, days::period>>;
 
-using months =
-    std::chrono::duration<int,
-                          detail::ratio_divide<years::period, std::ratio<12>>>;
+using months = std::chrono::duration
+    <int, detail::ratio_divide<years::period, std::ratio<12>>>;
 
 // time_point
 
 template <class Duration>
-using sys_time = std::chrono::time_point<std::chrono::system_clock, Duration>;
+    using sys_time = std::chrono::time_point<std::chrono::system_clock, Duration>;
 
-using sys_days = sys_time<days>;
+using sys_days    = sys_time<days>;
 using sys_seconds = sys_time<std::chrono::seconds>;
 
 struct local_t {};
 
 template <class Duration>
-using local_time = std::chrono::time_point<local_t, Duration>;
+    using local_time = std::chrono::time_point<local_t, Duration>;
 
 using local_seconds = local_time<std::chrono::seconds>;
-using local_days = local_time<days>;
+using local_days    = local_time<days>;
 
 // types
 
-struct last_spec {
-  explicit last_spec() = default;
+struct last_spec
+{
+    explicit last_spec() = default;
 };
 
 class day;
@@ -231,307 +231,307 @@ class year_month_weekday_last;
 // date composition operators
 
 CONSTCD11 year_month operator/(const year& y, const month& m) NOEXCEPT;
-CONSTCD11 year_month operator/(const year& y, int m) NOEXCEPT;
+CONSTCD11 year_month operator/(const year& y, int          m) NOEXCEPT;
 
 CONSTCD11 month_day operator/(const day& d, const month& m) NOEXCEPT;
-CONSTCD11 month_day operator/(const day& d, int m) NOEXCEPT;
+CONSTCD11 month_day operator/(const day& d, int          m) NOEXCEPT;
 CONSTCD11 month_day operator/(const month& m, const day& d) NOEXCEPT;
-CONSTCD11 month_day operator/(const month& m, int d) NOEXCEPT;
-CONSTCD11 month_day operator/(int m, const day& d) NOEXCEPT;
+CONSTCD11 month_day operator/(const month& m, int        d) NOEXCEPT;
+CONSTCD11 month_day operator/(int          m, const day& d) NOEXCEPT;
 
 CONSTCD11 month_day_last operator/(const month& m, last_spec) NOEXCEPT;
-CONSTCD11 month_day_last operator/(int m, last_spec) NOEXCEPT;
+CONSTCD11 month_day_last operator/(int          m, last_spec) NOEXCEPT;
 CONSTCD11 month_day_last operator/(last_spec, const month& m) NOEXCEPT;
-CONSTCD11 month_day_last operator/(last_spec, int m) NOEXCEPT;
+CONSTCD11 month_day_last operator/(last_spec, int          m) NOEXCEPT;
 
-CONSTCD11 month_weekday operator/(const month& m,
-                                  const weekday_indexed& wdi) NOEXCEPT;
-CONSTCD11 month_weekday operator/(int m, const weekday_indexed& wdi) NOEXCEPT;
-CONSTCD11 month_weekday operator/(const weekday_indexed& wdi,
-                                  const month& m) NOEXCEPT;
-CONSTCD11 month_weekday operator/(const weekday_indexed& wdi, int m) NOEXCEPT;
+CONSTCD11 month_weekday operator/(const month& m, const weekday_indexed& wdi) NOEXCEPT;
+CONSTCD11 month_weekday operator/(int          m, const weekday_indexed& wdi) NOEXCEPT;
+CONSTCD11 month_weekday operator/(const weekday_indexed& wdi, const month& m) NOEXCEPT;
+CONSTCD11 month_weekday operator/(const weekday_indexed& wdi, int          m) NOEXCEPT;
 
-CONSTCD11 month_weekday_last operator/(const month& m,
-                                       const weekday_last& wdl) NOEXCEPT;
-CONSTCD11 month_weekday_last operator/(int m, const weekday_last& wdl) NOEXCEPT;
-CONSTCD11 month_weekday_last operator/(const weekday_last& wdl,
-                                       const month& m) NOEXCEPT;
-CONSTCD11 month_weekday_last operator/(const weekday_last& wdl, int m) NOEXCEPT;
+CONSTCD11 month_weekday_last operator/(const month& m, const weekday_last& wdl) NOEXCEPT;
+CONSTCD11 month_weekday_last operator/(int          m, const weekday_last& wdl) NOEXCEPT;
+CONSTCD11 month_weekday_last operator/(const weekday_last& wdl, const month& m) NOEXCEPT;
+CONSTCD11 month_weekday_last operator/(const weekday_last& wdl, int          m) NOEXCEPT;
 
 CONSTCD11 year_month_day operator/(const year_month& ym, const day& d) NOEXCEPT;
-CONSTCD11 year_month_day operator/(const year_month& ym, int d) NOEXCEPT;
+CONSTCD11 year_month_day operator/(const year_month& ym, int        d) NOEXCEPT;
 CONSTCD11 year_month_day operator/(const year& y, const month_day& md) NOEXCEPT;
-CONSTCD11 year_month_day operator/(int y, const month_day& md) NOEXCEPT;
+CONSTCD11 year_month_day operator/(int         y, const month_day& md) NOEXCEPT;
 CONSTCD11 year_month_day operator/(const month_day& md, const year& y) NOEXCEPT;
-CONSTCD11 year_month_day operator/(const month_day& md, int y) NOEXCEPT;
+CONSTCD11 year_month_day operator/(const month_day& md, int         y) NOEXCEPT;
 
 CONSTCD11
-year_month_day_last operator/(const year_month& ym, last_spec) NOEXCEPT;
+    year_month_day_last operator/(const year_month& ym,   last_spec) NOEXCEPT;
 CONSTCD11
-year_month_day_last operator/(const year& y,
-                              const month_day_last& mdl) NOEXCEPT;
+    year_month_day_last operator/(const year& y, const month_day_last& mdl) NOEXCEPT;
 CONSTCD11
-year_month_day_last operator/(int y, const month_day_last& mdl) NOEXCEPT;
+    year_month_day_last operator/(int         y, const month_day_last& mdl) NOEXCEPT;
 CONSTCD11
-year_month_day_last operator/(const month_day_last& mdl,
-                              const year& y) NOEXCEPT;
+    year_month_day_last operator/(const month_day_last& mdl, const year& y) NOEXCEPT;
 CONSTCD11
-year_month_day_last operator/(const month_day_last& mdl, int y) NOEXCEPT;
+    year_month_day_last operator/(const month_day_last& mdl, int         y) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator/(const year_month& ym,
-                             const weekday_indexed& wdi) NOEXCEPT;
+year_month_weekday
+operator/(const year_month& ym, const weekday_indexed& wdi) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator/(const year& y, const month_weekday& mwd) NOEXCEPT;
+year_month_weekday
+operator/(const year&        y, const month_weekday&   mwd) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator/(int y, const month_weekday& mwd) NOEXCEPT;
+year_month_weekday
+operator/(int                y, const month_weekday&   mwd) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator/(const month_weekday& mwd, const year& y) NOEXCEPT;
+year_month_weekday
+operator/(const month_weekday& mwd, const year&          y) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator/(const month_weekday& mwd, int y) NOEXCEPT;
+year_month_weekday
+operator/(const month_weekday& mwd, int                  y) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator/(const year_month& ym,
-                                  const weekday_last& wdl) NOEXCEPT;
+year_month_weekday_last
+operator/(const year_month& ym, const weekday_last& wdl) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator/(const year& y,
-                                  const month_weekday_last& mwdl) NOEXCEPT;
+year_month_weekday_last
+operator/(const year& y, const month_weekday_last& mwdl) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator/(int y,
-                                  const month_weekday_last& mwdl) NOEXCEPT;
+year_month_weekday_last
+operator/(int         y, const month_weekday_last& mwdl) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator/(const month_weekday_last& mwdl,
-                                  const year& y) NOEXCEPT;
+year_month_weekday_last
+operator/(const month_weekday_last& mwdl, const year& y) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator/(const month_weekday_last& mwdl,
-                                  int y) NOEXCEPT;
+year_month_weekday_last
+operator/(const month_weekday_last& mwdl, int         y) NOEXCEPT;
 
 // Detailed interface
 
 // day
 
-class day {
-  unsigned char d_;
+class day
+{
+    unsigned char d_;
 
- public:
-  day() = default;
-  explicit CONSTCD11 day(unsigned d) NOEXCEPT;
+public:
+    day() = default;
+    explicit CONSTCD11 day(unsigned d) NOEXCEPT;
 
-  CONSTCD14 day& operator++() NOEXCEPT;
-  CONSTCD14 day operator++(int) NOEXCEPT;
-  CONSTCD14 day& operator--() NOEXCEPT;
-  CONSTCD14 day operator--(int) NOEXCEPT;
+    CONSTCD14 day& operator++()    NOEXCEPT;
+    CONSTCD14 day  operator++(int) NOEXCEPT;
+    CONSTCD14 day& operator--()    NOEXCEPT;
+    CONSTCD14 day  operator--(int) NOEXCEPT;
 
-  CONSTCD14 day& operator+=(const days& d) NOEXCEPT;
-  CONSTCD14 day& operator-=(const days& d) NOEXCEPT;
+    CONSTCD14 day& operator+=(const days& d) NOEXCEPT;
+    CONSTCD14 day& operator-=(const days& d) NOEXCEPT;
 
-  CONSTCD11 explicit operator unsigned() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 explicit operator unsigned() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11 bool operator==(const day& x, const day& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const day& x, const day& y) NOEXCEPT;
-CONSTCD11 bool operator<(const day& x, const day& y) NOEXCEPT;
-CONSTCD11 bool operator>(const day& x, const day& y) NOEXCEPT;
+CONSTCD11 bool operator< (const day& x, const day& y) NOEXCEPT;
+CONSTCD11 bool operator> (const day& x, const day& y) NOEXCEPT;
 CONSTCD11 bool operator<=(const day& x, const day& y) NOEXCEPT;
 CONSTCD11 bool operator>=(const day& x, const day& y) NOEXCEPT;
 
-CONSTCD11 day operator+(const day& x, const days& y) NOEXCEPT;
-CONSTCD11 day operator+(const days& x, const day& y) NOEXCEPT;
-CONSTCD11 day operator-(const day& x, const days& y) NOEXCEPT;
-CONSTCD11 days operator-(const day& x, const day& y) NOEXCEPT;
+CONSTCD11 day  operator+(const day&  x, const days& y) NOEXCEPT;
+CONSTCD11 day  operator+(const days& x, const day&  y) NOEXCEPT;
+CONSTCD11 day  operator-(const day&  x, const days& y) NOEXCEPT;
+CONSTCD11 days operator-(const day&  x, const day&  y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const day& d);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const day& d);
 
 // month
 
-class month {
-  unsigned char m_;
+class month
+{
+    unsigned char m_;
 
- public:
-  month() = default;
-  explicit CONSTCD11 month(unsigned m) NOEXCEPT;
+public:
+    month() = default;
+    explicit CONSTCD11 month(unsigned m) NOEXCEPT;
 
-  CONSTCD14 month& operator++() NOEXCEPT;
-  CONSTCD14 month operator++(int) NOEXCEPT;
-  CONSTCD14 month& operator--() NOEXCEPT;
-  CONSTCD14 month operator--(int) NOEXCEPT;
+    CONSTCD14 month& operator++()    NOEXCEPT;
+    CONSTCD14 month  operator++(int) NOEXCEPT;
+    CONSTCD14 month& operator--()    NOEXCEPT;
+    CONSTCD14 month  operator--(int) NOEXCEPT;
 
-  CONSTCD14 month& operator+=(const months& m) NOEXCEPT;
-  CONSTCD14 month& operator-=(const months& m) NOEXCEPT;
+    CONSTCD14 month& operator+=(const months& m) NOEXCEPT;
+    CONSTCD14 month& operator-=(const months& m) NOEXCEPT;
 
-  CONSTCD11 explicit operator unsigned() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 explicit operator unsigned() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11 bool operator==(const month& x, const month& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const month& x, const month& y) NOEXCEPT;
-CONSTCD11 bool operator<(const month& x, const month& y) NOEXCEPT;
-CONSTCD11 bool operator>(const month& x, const month& y) NOEXCEPT;
+CONSTCD11 bool operator< (const month& x, const month& y) NOEXCEPT;
+CONSTCD11 bool operator> (const month& x, const month& y) NOEXCEPT;
 CONSTCD11 bool operator<=(const month& x, const month& y) NOEXCEPT;
 CONSTCD11 bool operator>=(const month& x, const month& y) NOEXCEPT;
 
-CONSTCD14 month operator+(const month& x, const months& y) NOEXCEPT;
-CONSTCD14 month operator+(const months& x, const month& y) NOEXCEPT;
-CONSTCD14 month operator-(const month& x, const months& y) NOEXCEPT;
-CONSTCD14 months operator-(const month& x, const month& y) NOEXCEPT;
+CONSTCD14 month  operator+(const month&  x, const months& y) NOEXCEPT;
+CONSTCD14 month  operator+(const months& x,  const month& y) NOEXCEPT;
+CONSTCD14 month  operator-(const month&  x, const months& y) NOEXCEPT;
+CONSTCD14 months operator-(const month&  x,  const month& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month& m);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month& m);
 
 // year
 
-class year {
-  short y_;
+class year
+{
+    short y_;
 
- public:
-  year() = default;
-  explicit CONSTCD11 year(int y) NOEXCEPT;
+public:
+    year() = default;
+    explicit CONSTCD11 year(int y) NOEXCEPT;
 
-  CONSTCD14 year& operator++() NOEXCEPT;
-  CONSTCD14 year operator++(int) NOEXCEPT;
-  CONSTCD14 year& operator--() NOEXCEPT;
-  CONSTCD14 year operator--(int) NOEXCEPT;
+    CONSTCD14 year& operator++()    NOEXCEPT;
+    CONSTCD14 year  operator++(int) NOEXCEPT;
+    CONSTCD14 year& operator--()    NOEXCEPT;
+    CONSTCD14 year  operator--(int) NOEXCEPT;
 
-  CONSTCD14 year& operator+=(const years& y) NOEXCEPT;
-  CONSTCD14 year& operator-=(const years& y) NOEXCEPT;
+    CONSTCD14 year& operator+=(const years& y) NOEXCEPT;
+    CONSTCD14 year& operator-=(const years& y) NOEXCEPT;
 
-  CONSTCD11 year operator-() const NOEXCEPT;
-  CONSTCD11 year operator+() const NOEXCEPT;
+    CONSTCD11 year operator-() const NOEXCEPT;
+    CONSTCD11 year operator+() const NOEXCEPT;
 
-  CONSTCD11 bool is_leap() const NOEXCEPT;
+    CONSTCD11 bool is_leap() const NOEXCEPT;
 
-  CONSTCD11 explicit operator int() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 explicit operator int() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 
-  static CONSTCD11 year min() NOEXCEPT { return year{-32767}; }
-  static CONSTCD11 year max() NOEXCEPT { return year{32767}; }
+    static CONSTCD11 year min() NOEXCEPT { return year{-32767}; }
+    static CONSTCD11 year max() NOEXCEPT { return year{32767}; }
 };
 
 CONSTCD11 bool operator==(const year& x, const year& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator<(const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator>(const year& x, const year& y) NOEXCEPT;
+CONSTCD11 bool operator< (const year& x, const year& y) NOEXCEPT;
+CONSTCD11 bool operator> (const year& x, const year& y) NOEXCEPT;
 CONSTCD11 bool operator<=(const year& x, const year& y) NOEXCEPT;
 CONSTCD11 bool operator>=(const year& x, const year& y) NOEXCEPT;
 
-CONSTCD11 year operator+(const year& x, const years& y) NOEXCEPT;
-CONSTCD11 year operator+(const years& x, const year& y) NOEXCEPT;
-CONSTCD11 year operator-(const year& x, const years& y) NOEXCEPT;
-CONSTCD11 years operator-(const year& x, const year& y) NOEXCEPT;
+CONSTCD11 year  operator+(const year&  x, const years& y) NOEXCEPT;
+CONSTCD11 year  operator+(const years& x, const year&  y) NOEXCEPT;
+CONSTCD11 year  operator-(const year&  x, const years& y) NOEXCEPT;
+CONSTCD11 years operator-(const year&  x, const year&  y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year& y);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year& y);
 
 // weekday
 
-class weekday {
-  unsigned char wd_;
+class weekday
+{
+    unsigned char wd_;
+public:
+    weekday() = default;
+    explicit CONSTCD11 weekday(unsigned wd) NOEXCEPT;
+    CONSTCD14 weekday(const sys_days& dp) NOEXCEPT;
+    CONSTCD14 explicit weekday(const local_days& dp) NOEXCEPT;
 
- public:
-  weekday() = default;
-  explicit CONSTCD11 weekday(unsigned wd) NOEXCEPT;
-  CONSTCD14 weekday(const sys_days& dp) NOEXCEPT;
-  CONSTCD14 explicit weekday(const local_days& dp) NOEXCEPT;
+    CONSTCD14 weekday& operator++()    NOEXCEPT;
+    CONSTCD14 weekday  operator++(int) NOEXCEPT;
+    CONSTCD14 weekday& operator--()    NOEXCEPT;
+    CONSTCD14 weekday  operator--(int) NOEXCEPT;
 
-  CONSTCD14 weekday& operator++() NOEXCEPT;
-  CONSTCD14 weekday operator++(int) NOEXCEPT;
-  CONSTCD14 weekday& operator--() NOEXCEPT;
-  CONSTCD14 weekday operator--(int) NOEXCEPT;
+    CONSTCD14 weekday& operator+=(const days& d) NOEXCEPT;
+    CONSTCD14 weekday& operator-=(const days& d) NOEXCEPT;
 
-  CONSTCD14 weekday& operator+=(const days& d) NOEXCEPT;
-  CONSTCD14 weekday& operator-=(const days& d) NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 unsigned c_encoding() const NOEXCEPT;
+    CONSTCD11 unsigned iso_encoding() const NOEXCEPT;
 
-  CONSTCD11 unsigned c_encoding() const NOEXCEPT;
-  CONSTCD11 unsigned iso_encoding() const NOEXCEPT;
+    CONSTCD11 weekday_indexed operator[](unsigned index) const NOEXCEPT;
+    CONSTCD11 weekday_last    operator[](last_spec)      const NOEXCEPT;
 
-  CONSTCD11 weekday_indexed operator[](unsigned index) const NOEXCEPT;
-  CONSTCD11 weekday_last operator[](last_spec) const NOEXCEPT;
+private:
+    static CONSTCD14 unsigned char weekday_from_days(int z) NOEXCEPT;
 
- private:
-  static CONSTCD14 unsigned char weekday_from_days(int z) NOEXCEPT;
-
-  friend CONSTCD11 bool operator==(const weekday& x, const weekday& y) NOEXCEPT;
-  friend CONSTCD14 days operator-(const weekday& x, const weekday& y) NOEXCEPT;
-  friend CONSTCD14 weekday operator+(const weekday& x, const days& y) NOEXCEPT;
-  template <class CharT, class Traits>
-  friend std::basic_ostream<CharT, Traits>& operator<<(
-      std::basic_ostream<CharT, Traits>& os, const weekday& wd);
-  friend class weekday_indexed;
+    friend CONSTCD11 bool operator==(const weekday& x, const weekday& y) NOEXCEPT;
+    friend CONSTCD14 days operator-(const weekday& x, const weekday& y) NOEXCEPT;
+    friend CONSTCD14 weekday operator+(const weekday& x, const days& y) NOEXCEPT;
+    template<class CharT, class Traits>
+        friend std::basic_ostream<CharT, Traits>&
+            operator<<(std::basic_ostream<CharT, Traits>& os, const weekday& wd);
+    friend class weekday_indexed;
 };
 
 CONSTCD11 bool operator==(const weekday& x, const weekday& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const weekday& x, const weekday& y) NOEXCEPT;
 
-CONSTCD14 weekday operator+(const weekday& x, const days& y) NOEXCEPT;
-CONSTCD14 weekday operator+(const days& x, const weekday& y) NOEXCEPT;
-CONSTCD14 weekday operator-(const weekday& x, const days& y) NOEXCEPT;
-CONSTCD14 days operator-(const weekday& x, const weekday& y) NOEXCEPT;
+CONSTCD14 weekday operator+(const weekday& x, const days&    y) NOEXCEPT;
+CONSTCD14 weekday operator+(const days&    x, const weekday& y) NOEXCEPT;
+CONSTCD14 weekday operator-(const weekday& x, const days&    y) NOEXCEPT;
+CONSTCD14 days    operator-(const weekday& x, const weekday& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday& wd);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday& wd);
 
 // weekday_indexed
 
-class weekday_indexed {
-  unsigned char wd_ : 4;
-  unsigned char index_ : 4;
+class weekday_indexed
+{
+    unsigned char wd_    : 4;
+    unsigned char index_ : 4;
 
- public:
-  weekday_indexed() = default;
-  CONSTCD11 weekday_indexed(const date::weekday& wd, unsigned index) NOEXCEPT;
+public:
+    weekday_indexed() = default;
+    CONSTCD11 weekday_indexed(const date::weekday& wd, unsigned index) NOEXCEPT;
 
-  CONSTCD11 date::weekday weekday() const NOEXCEPT;
-  CONSTCD11 unsigned index() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
+    CONSTCD11 unsigned index() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
-CONSTCD11 bool operator==(const weekday_indexed& x,
-                          const weekday_indexed& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const weekday_indexed& x,
-                          const weekday_indexed& y) NOEXCEPT;
+CONSTCD11 bool operator==(const weekday_indexed& x, const weekday_indexed& y) NOEXCEPT;
+CONSTCD11 bool operator!=(const weekday_indexed& x, const weekday_indexed& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi);
 
 // weekday_last
 
-class weekday_last {
-  date::weekday wd_;
+class weekday_last
+{
+    date::weekday wd_;
 
- public:
-  explicit CONSTCD11 weekday_last(const date::weekday& wd) NOEXCEPT;
+public:
+    explicit CONSTCD11 weekday_last(const date::weekday& wd) NOEXCEPT;
 
-  CONSTCD11 date::weekday weekday() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
-CONSTCD11 bool operator==(const weekday_last& x,
-                          const weekday_last& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const weekday_last& x,
-                          const weekday_last& y) NOEXCEPT;
+CONSTCD11 bool operator==(const weekday_last& x, const weekday_last& y) NOEXCEPT;
+CONSTCD11 bool operator!=(const weekday_last& x, const weekday_last& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl);
 
-namespace detail {
+namespace detail
+{
 
 struct unspecified_month_disambiguator {};
 
@@ -539,39 +539,40 @@ struct unspecified_month_disambiguator {};
 
 // year_month
 
-class year_month {
-  date::year y_;
-  date::month m_;
+class year_month
+{
+    date::year  y_;
+    date::month m_;
 
- public:
-  year_month() = default;
-  CONSTCD11 year_month(const date::year& y, const date::month& m) NOEXCEPT;
+public:
+    year_month() = default;
+    CONSTCD11 year_month(const date::year& y, const date::month& m) NOEXCEPT;
 
-  CONSTCD11 date::year year() const NOEXCEPT;
-  CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 date::year  year()  const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
 
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month& operator+=(const months& dm) NOEXCEPT;
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month& operator-=(const months& dm) NOEXCEPT;
-  CONSTCD14 year_month& operator+=(const years& dy) NOEXCEPT;
-  CONSTCD14 year_month& operator-=(const years& dy) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month& operator+=(const months& dm) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month& operator-=(const months& dm) NOEXCEPT;
+    CONSTCD14 year_month& operator+=(const years& dy) NOEXCEPT;
+    CONSTCD14 year_month& operator-=(const years& dy) NOEXCEPT;
 
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11 bool operator==(const year_month& x, const year_month& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const year_month& x, const year_month& y) NOEXCEPT;
-CONSTCD11 bool operator<(const year_month& x, const year_month& y) NOEXCEPT;
-CONSTCD11 bool operator>(const year_month& x, const year_month& y) NOEXCEPT;
+CONSTCD11 bool operator< (const year_month& x, const year_month& y) NOEXCEPT;
+CONSTCD11 bool operator> (const year_month& x, const year_month& y) NOEXCEPT;
 CONSTCD11 bool operator<=(const year_month& x, const year_month& y) NOEXCEPT;
 CONSTCD11 bool operator>=(const year_month& x, const year_month& y) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
+template<class = detail::unspecified_month_disambiguator>
 CONSTCD14 year_month operator+(const year_month& ym, const months& dm) NOEXCEPT;
-template <class = detail::unspecified_month_disambiguator>
+template<class = detail::unspecified_month_disambiguator>
 CONSTCD14 year_month operator+(const months& dm, const year_month& ym) NOEXCEPT;
-template <class = detail::unspecified_month_disambiguator>
+template<class = detail::unspecified_month_disambiguator>
 CONSTCD14 year_month operator-(const year_month& ym, const months& dm) NOEXCEPT;
 
 CONSTCD11 months operator-(const year_month& x, const year_month& y) NOEXCEPT;
@@ -579,408 +580,394 @@ CONSTCD11 year_month operator+(const year_month& ym, const years& dy) NOEXCEPT;
 CONSTCD11 year_month operator+(const years& dy, const year_month& ym) NOEXCEPT;
 CONSTCD11 year_month operator-(const year_month& ym, const years& dy) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month& ym);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month& ym);
 
 // month_day
 
-class month_day {
-  date::month m_;
-  date::day d_;
+class month_day
+{
+    date::month m_;
+    date::day   d_;
 
- public:
-  month_day() = default;
-  CONSTCD11 month_day(const date::month& m, const date::day& d) NOEXCEPT;
+public:
+    month_day() = default;
+    CONSTCD11 month_day(const date::month& m, const date::day& d) NOEXCEPT;
 
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::day day() const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 date::day   day() const NOEXCEPT;
 
-  CONSTCD14 bool ok() const NOEXCEPT;
+    CONSTCD14 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11 bool operator==(const month_day& x, const month_day& y) NOEXCEPT;
 CONSTCD11 bool operator!=(const month_day& x, const month_day& y) NOEXCEPT;
-CONSTCD11 bool operator<(const month_day& x, const month_day& y) NOEXCEPT;
-CONSTCD11 bool operator>(const month_day& x, const month_day& y) NOEXCEPT;
+CONSTCD11 bool operator< (const month_day& x, const month_day& y) NOEXCEPT;
+CONSTCD11 bool operator> (const month_day& x, const month_day& y) NOEXCEPT;
 CONSTCD11 bool operator<=(const month_day& x, const month_day& y) NOEXCEPT;
 CONSTCD11 bool operator>=(const month_day& x, const month_day& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_day& md);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_day& md);
 
 // month_day_last
 
-class month_day_last {
-  date::month m_;
+class month_day_last
+{
+    date::month m_;
 
- public:
-  CONSTCD11 explicit month_day_last(const date::month& m) NOEXCEPT;
+public:
+    CONSTCD11 explicit month_day_last(const date::month& m) NOEXCEPT;
 
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
-CONSTCD11 bool operator==(const month_day_last& x,
-                          const month_day_last& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const month_day_last& x,
-                          const month_day_last& y) NOEXCEPT;
-CONSTCD11 bool operator<(const month_day_last& x,
-                         const month_day_last& y) NOEXCEPT;
-CONSTCD11 bool operator>(const month_day_last& x,
-                         const month_day_last& y) NOEXCEPT;
-CONSTCD11 bool operator<=(const month_day_last& x,
-                          const month_day_last& y) NOEXCEPT;
-CONSTCD11 bool operator>=(const month_day_last& x,
-                          const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator==(const month_day_last& x, const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator!=(const month_day_last& x, const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator< (const month_day_last& x, const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator> (const month_day_last& x, const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator<=(const month_day_last& x, const month_day_last& y) NOEXCEPT;
+CONSTCD11 bool operator>=(const month_day_last& x, const month_day_last& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl);
 
 // month_weekday
 
-class month_weekday {
-  date::month m_;
-  date::weekday_indexed wdi_;
+class month_weekday
+{
+    date::month           m_;
+    date::weekday_indexed wdi_;
+public:
+    CONSTCD11 month_weekday(const date::month& m,
+                            const date::weekday_indexed& wdi) NOEXCEPT;
 
- public:
-  CONSTCD11 month_weekday(const date::month& m,
-                          const date::weekday_indexed& wdi) NOEXCEPT;
+    CONSTCD11 date::month           month()           const NOEXCEPT;
+    CONSTCD11 date::weekday_indexed weekday_indexed() const NOEXCEPT;
 
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::weekday_indexed weekday_indexed() const NOEXCEPT;
-
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
-CONSTCD11 bool operator==(const month_weekday& x,
-                          const month_weekday& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const month_weekday& x,
-                          const month_weekday& y) NOEXCEPT;
+CONSTCD11 bool operator==(const month_weekday& x, const month_weekday& y) NOEXCEPT;
+CONSTCD11 bool operator!=(const month_weekday& x, const month_weekday& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd);
 
 // month_weekday_last
 
-class month_weekday_last {
-  date::month m_;
-  date::weekday_last wdl_;
+class month_weekday_last
+{
+    date::month        m_;
+    date::weekday_last wdl_;
 
- public:
-  CONSTCD11 month_weekday_last(const date::month& m,
-                               const date::weekday_last& wd) NOEXCEPT;
+public:
+    CONSTCD11 month_weekday_last(const date::month& m,
+                                 const date::weekday_last& wd) NOEXCEPT;
 
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::weekday_last weekday_last() const NOEXCEPT;
+    CONSTCD11 date::month        month()        const NOEXCEPT;
+    CONSTCD11 date::weekday_last weekday_last() const NOEXCEPT;
 
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11
-bool operator==(const month_weekday_last& x,
-                const month_weekday_last& y) NOEXCEPT;
+    bool operator==(const month_weekday_last& x, const month_weekday_last& y) NOEXCEPT;
 CONSTCD11
-bool operator!=(const month_weekday_last& x,
-                const month_weekday_last& y) NOEXCEPT;
+    bool operator!=(const month_weekday_last& x, const month_weekday_last& y) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl);
 
 // class year_month_day
 
-class year_month_day {
-  date::year y_;
-  date::month m_;
-  date::day d_;
+class year_month_day
+{
+    date::year  y_;
+    date::month m_;
+    date::day   d_;
 
- public:
-  year_month_day() = default;
-  CONSTCD11 year_month_day(const date::year& y, const date::month& m,
-                           const date::day& d) NOEXCEPT;
-  CONSTCD14 year_month_day(const year_month_day_last& ymdl) NOEXCEPT;
+public:
+    year_month_day() = default;
+    CONSTCD11 year_month_day(const date::year& y, const date::month& m,
+                             const date::day& d) NOEXCEPT;
+    CONSTCD14 year_month_day(const year_month_day_last& ymdl) NOEXCEPT;
 
-  CONSTCD14 year_month_day(sys_days dp) NOEXCEPT;
-  CONSTCD14 explicit year_month_day(local_days dp) NOEXCEPT;
+    CONSTCD14 year_month_day(sys_days dp) NOEXCEPT;
+    CONSTCD14 explicit year_month_day(local_days dp) NOEXCEPT;
 
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_day& operator+=(const months& m) NOEXCEPT;
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_day& operator-=(const months& m) NOEXCEPT;
-  CONSTCD14 year_month_day& operator+=(const years& y) NOEXCEPT;
-  CONSTCD14 year_month_day& operator-=(const years& y) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_day& operator+=(const months& m) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_day& operator-=(const months& m) NOEXCEPT;
+    CONSTCD14 year_month_day& operator+=(const years& y)  NOEXCEPT;
+    CONSTCD14 year_month_day& operator-=(const years& y)  NOEXCEPT;
 
-  CONSTCD11 date::year year() const NOEXCEPT;
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::day day() const NOEXCEPT;
+    CONSTCD11 date::year  year()  const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 date::day   day()   const NOEXCEPT;
 
-  CONSTCD14 operator sys_days() const NOEXCEPT;
-  CONSTCD14 explicit operator local_days() const NOEXCEPT;
-  CONSTCD14 bool ok() const NOEXCEPT;
+    CONSTCD14 operator sys_days() const NOEXCEPT;
+    CONSTCD14 explicit operator local_days() const NOEXCEPT;
+    CONSTCD14 bool ok() const NOEXCEPT;
 
- private:
-  static CONSTCD14 year_month_day from_days(days dp) NOEXCEPT;
-  CONSTCD14 days to_days() const NOEXCEPT;
+private:
+    static CONSTCD14 year_month_day from_days(days dp) NOEXCEPT;
+    CONSTCD14 days to_days() const NOEXCEPT;
 };
 
-CONSTCD11 bool operator==(const year_month_day& x,
-                          const year_month_day& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const year_month_day& x,
-                          const year_month_day& y) NOEXCEPT;
-CONSTCD11 bool operator<(const year_month_day& x,
-                         const year_month_day& y) NOEXCEPT;
-CONSTCD11 bool operator>(const year_month_day& x,
-                         const year_month_day& y) NOEXCEPT;
-CONSTCD11 bool operator<=(const year_month_day& x,
-                          const year_month_day& y) NOEXCEPT;
-CONSTCD11 bool operator>=(const year_month_day& x,
-                          const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator==(const year_month_day& x, const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator!=(const year_month_day& x, const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator< (const year_month_day& x, const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator> (const year_month_day& x, const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator<=(const year_month_day& x, const year_month_day& y) NOEXCEPT;
+CONSTCD11 bool operator>=(const year_month_day& x, const year_month_day& y) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day operator+(const year_month_day& ymd,
-                                   const months& dm) NOEXCEPT;
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day operator+(const months& dm,
-                                   const year_month_day& ymd) NOEXCEPT;
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day operator-(const year_month_day& ymd,
-                                   const months& dm) NOEXCEPT;
-CONSTCD11 year_month_day operator+(const year_month_day& ymd,
-                                   const years& dy) NOEXCEPT;
-CONSTCD11 year_month_day operator+(const years& dy,
-                                   const year_month_day& ymd) NOEXCEPT;
-CONSTCD11 year_month_day operator-(const year_month_day& ymd,
-                                   const years& dy) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14 year_month_day operator+(const year_month_day& ymd, const months& dm) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14 year_month_day operator+(const months& dm, const year_month_day& ymd) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14 year_month_day operator-(const year_month_day& ymd, const months& dm) NOEXCEPT;
+CONSTCD11 year_month_day operator+(const year_month_day& ymd, const years& dy)  NOEXCEPT;
+CONSTCD11 year_month_day operator+(const years& dy, const year_month_day& ymd)  NOEXCEPT;
+CONSTCD11 year_month_day operator-(const year_month_day& ymd, const years& dy)  NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_day& ymd);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_day& ymd);
 
 // year_month_day_last
 
-class year_month_day_last {
-  date::year y_;
-  date::month_day_last mdl_;
+class year_month_day_last
+{
+    date::year           y_;
+    date::month_day_last mdl_;
 
- public:
-  CONSTCD11 year_month_day_last(const date::year& y,
-                                const date::month_day_last& mdl) NOEXCEPT;
+public:
+    CONSTCD11 year_month_day_last(const date::year& y,
+                                  const date::month_day_last& mdl) NOEXCEPT;
 
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_day_last& operator+=(const months& m) NOEXCEPT;
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_day_last& operator-=(const months& m) NOEXCEPT;
-  CONSTCD14 year_month_day_last& operator+=(const years& y) NOEXCEPT;
-  CONSTCD14 year_month_day_last& operator-=(const years& y) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_day_last& operator+=(const months& m) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_day_last& operator-=(const months& m) NOEXCEPT;
+    CONSTCD14 year_month_day_last& operator+=(const years& y)  NOEXCEPT;
+    CONSTCD14 year_month_day_last& operator-=(const years& y)  NOEXCEPT;
 
-  CONSTCD11 date::year year() const NOEXCEPT;
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::month_day_last month_day_last() const NOEXCEPT;
-  CONSTCD14 date::day day() const NOEXCEPT;
+    CONSTCD11 date::year           year()           const NOEXCEPT;
+    CONSTCD11 date::month          month()          const NOEXCEPT;
+    CONSTCD11 date::month_day_last month_day_last() const NOEXCEPT;
+    CONSTCD14 date::day            day()            const NOEXCEPT;
 
-  CONSTCD14 operator sys_days() const NOEXCEPT;
-  CONSTCD14 explicit operator local_days() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD14 operator sys_days() const NOEXCEPT;
+    CONSTCD14 explicit operator local_days() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 };
 
 CONSTCD11
-bool operator==(const year_month_day_last& x,
-                const year_month_day_last& y) NOEXCEPT;
+    bool operator==(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 CONSTCD11
-bool operator!=(const year_month_day_last& x,
-                const year_month_day_last& y) NOEXCEPT;
+    bool operator!=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 CONSTCD11
-bool operator<(const year_month_day_last& x,
-               const year_month_day_last& y) NOEXCEPT;
+    bool operator< (const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 CONSTCD11
-bool operator>(const year_month_day_last& x,
-               const year_month_day_last& y) NOEXCEPT;
+    bool operator> (const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 CONSTCD11
-bool operator<=(const year_month_day_last& x,
-                const year_month_day_last& y) NOEXCEPT;
+    bool operator<=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 CONSTCD11
-bool operator>=(const year_month_day_last& x,
-                const year_month_day_last& y) NOEXCEPT;
+    bool operator>=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day_last operator+(const year_month_day_last& ymdl,
-                                        const months& dm) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_day_last
+operator+(const year_month_day_last& ymdl, const months& dm) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day_last
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_day_last
 operator+(const months& dm, const year_month_day_last& ymdl) NOEXCEPT;
 
 CONSTCD11
-year_month_day_last operator+(const year_month_day_last& ymdl,
-                              const years& dy) NOEXCEPT;
+year_month_day_last
+operator+(const year_month_day_last& ymdl, const years& dy) NOEXCEPT;
 
 CONSTCD11
-year_month_day_last operator+(const years& dy,
-                              const year_month_day_last& ymdl) NOEXCEPT;
+year_month_day_last
+operator+(const years& dy, const year_month_day_last& ymdl) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_day_last operator-(const year_month_day_last& ymdl,
-                                        const months& dm) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_day_last
+operator-(const year_month_day_last& ymdl, const months& dm) NOEXCEPT;
 
 CONSTCD11
-year_month_day_last operator-(const year_month_day_last& ymdl,
-                              const years& dy) NOEXCEPT;
+year_month_day_last
+operator-(const year_month_day_last& ymdl, const years& dy) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl);
 
 // year_month_weekday
 
-class year_month_weekday {
-  date::year y_;
-  date::month m_;
-  date::weekday_indexed wdi_;
+class year_month_weekday
+{
+    date::year            y_;
+    date::month           m_;
+    date::weekday_indexed wdi_;
 
- public:
-  year_month_weekday() = default;
-  CONSTCD11 year_month_weekday(const date::year& y, const date::month& m,
-                               const date::weekday_indexed& wdi) NOEXCEPT;
-  CONSTCD14 year_month_weekday(const sys_days& dp) NOEXCEPT;
-  CONSTCD14 explicit year_month_weekday(const local_days& dp) NOEXCEPT;
+public:
+    year_month_weekday() = default;
+    CONSTCD11 year_month_weekday(const date::year& y, const date::month& m,
+                                   const date::weekday_indexed& wdi) NOEXCEPT;
+    CONSTCD14 year_month_weekday(const sys_days& dp) NOEXCEPT;
+    CONSTCD14 explicit year_month_weekday(const local_days& dp) NOEXCEPT;
 
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_weekday& operator+=(const months& m) NOEXCEPT;
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_weekday& operator-=(const months& m) NOEXCEPT;
-  CONSTCD14 year_month_weekday& operator+=(const years& y) NOEXCEPT;
-  CONSTCD14 year_month_weekday& operator-=(const years& y) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_weekday& operator+=(const months& m) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_weekday& operator-=(const months& m) NOEXCEPT;
+    CONSTCD14 year_month_weekday& operator+=(const years& y)  NOEXCEPT;
+    CONSTCD14 year_month_weekday& operator-=(const years& y)  NOEXCEPT;
 
-  CONSTCD11 date::year year() const NOEXCEPT;
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::weekday weekday() const NOEXCEPT;
-  CONSTCD11 unsigned index() const NOEXCEPT;
-  CONSTCD11 date::weekday_indexed weekday_indexed() const NOEXCEPT;
+    CONSTCD11 date::year year() const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
+    CONSTCD11 unsigned index() const NOEXCEPT;
+    CONSTCD11 date::weekday_indexed weekday_indexed() const NOEXCEPT;
 
-  CONSTCD14 operator sys_days() const NOEXCEPT;
-  CONSTCD14 explicit operator local_days() const NOEXCEPT;
-  CONSTCD14 bool ok() const NOEXCEPT;
+    CONSTCD14 operator sys_days() const NOEXCEPT;
+    CONSTCD14 explicit operator local_days() const NOEXCEPT;
+    CONSTCD14 bool ok() const NOEXCEPT;
 
- private:
-  static CONSTCD14 year_month_weekday from_days(days dp) NOEXCEPT;
-  CONSTCD14 days to_days() const NOEXCEPT;
+private:
+    static CONSTCD14 year_month_weekday from_days(days dp) NOEXCEPT;
+    CONSTCD14 days to_days() const NOEXCEPT;
 };
 
 CONSTCD11
-bool operator==(const year_month_weekday& x,
-                const year_month_weekday& y) NOEXCEPT;
+    bool operator==(const year_month_weekday& x, const year_month_weekday& y) NOEXCEPT;
 CONSTCD11
-bool operator!=(const year_month_weekday& x,
-                const year_month_weekday& y) NOEXCEPT;
+    bool operator!=(const year_month_weekday& x, const year_month_weekday& y) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday operator+(const year_month_weekday& ymwd,
-                                       const months& dm) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday
+operator+(const year_month_weekday& ymwd, const months& dm) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday operator+(const months& dm,
-                                       const year_month_weekday& ymwd) NOEXCEPT;
-
-CONSTCD11
-year_month_weekday operator+(const year_month_weekday& ymwd,
-                             const years& dy) NOEXCEPT;
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday
+operator+(const months& dm, const year_month_weekday& ymwd) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator+(const years& dy,
-                             const year_month_weekday& ymwd) NOEXCEPT;
-
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday operator-(const year_month_weekday& ymwd,
-                                       const months& dm) NOEXCEPT;
+year_month_weekday
+operator+(const year_month_weekday& ymwd, const years& dy) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday operator-(const year_month_weekday& ymwd,
-                             const years& dy) NOEXCEPT;
+year_month_weekday
+operator+(const years& dy, const year_month_weekday& ymwd) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_weekday& ymwdi);
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday
+operator-(const year_month_weekday& ymwd, const months& dm) NOEXCEPT;
+
+CONSTCD11
+year_month_weekday
+operator-(const year_month_weekday& ymwd, const years& dy) NOEXCEPT;
+
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday& ymwdi);
 
 // year_month_weekday_last
 
-class year_month_weekday_last {
-  date::year y_;
-  date::month m_;
-  date::weekday_last wdl_;
+class year_month_weekday_last
+{
+    date::year y_;
+    date::month m_;
+    date::weekday_last wdl_;
 
- public:
-  CONSTCD11 year_month_weekday_last(const date::year& y, const date::month& m,
-                                    const date::weekday_last& wdl) NOEXCEPT;
+public:
+    CONSTCD11 year_month_weekday_last(const date::year& y, const date::month& m,
+                                      const date::weekday_last& wdl) NOEXCEPT;
 
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_weekday_last& operator+=(const months& m) NOEXCEPT;
-  template <class = detail::unspecified_month_disambiguator>
-  CONSTCD14 year_month_weekday_last& operator-=(const months& m) NOEXCEPT;
-  CONSTCD14 year_month_weekday_last& operator+=(const years& y) NOEXCEPT;
-  CONSTCD14 year_month_weekday_last& operator-=(const years& y) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_weekday_last& operator+=(const months& m) NOEXCEPT;
+    template<class = detail::unspecified_month_disambiguator>
+    CONSTCD14 year_month_weekday_last& operator-=(const months& m) NOEXCEPT;
+    CONSTCD14 year_month_weekday_last& operator+=(const years& y) NOEXCEPT;
+    CONSTCD14 year_month_weekday_last& operator-=(const years& y) NOEXCEPT;
 
-  CONSTCD11 date::year year() const NOEXCEPT;
-  CONSTCD11 date::month month() const NOEXCEPT;
-  CONSTCD11 date::weekday weekday() const NOEXCEPT;
-  CONSTCD11 date::weekday_last weekday_last() const NOEXCEPT;
+    CONSTCD11 date::year year() const NOEXCEPT;
+    CONSTCD11 date::month month() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
+    CONSTCD11 date::weekday_last weekday_last() const NOEXCEPT;
 
-  CONSTCD14 operator sys_days() const NOEXCEPT;
-  CONSTCD14 explicit operator local_days() const NOEXCEPT;
-  CONSTCD11 bool ok() const NOEXCEPT;
+    CONSTCD14 operator sys_days() const NOEXCEPT;
+    CONSTCD14 explicit operator local_days() const NOEXCEPT;
+    CONSTCD11 bool ok() const NOEXCEPT;
 
- private:
-  CONSTCD14 days to_days() const NOEXCEPT;
+private:
+    CONSTCD14 days to_days() const NOEXCEPT;
 };
 
 CONSTCD11
-bool operator==(const year_month_weekday_last& x,
-                const year_month_weekday_last& y) NOEXCEPT;
+bool
+operator==(const year_month_weekday_last& x, const year_month_weekday_last& y) NOEXCEPT;
 
 CONSTCD11
-bool operator!=(const year_month_weekday_last& x,
-                const year_month_weekday_last& y) NOEXCEPT;
+bool
+operator!=(const year_month_weekday_last& x, const year_month_weekday_last& y) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday_last
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday_last
 operator+(const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday_last
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday_last
 operator+(const months& dm, const year_month_weekday_last& ymwdl) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator+(const year_month_weekday_last& ymwdl,
-                                  const years& dy) NOEXCEPT;
+year_month_weekday_last
+operator+(const year_month_weekday_last& ymwdl, const years& dy) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator+(
-    const years& dy, const year_month_weekday_last& ymwdl) NOEXCEPT;
+year_month_weekday_last
+operator+(const years& dy, const year_month_weekday_last& ymwdl) NOEXCEPT;
 
-template <class = detail::unspecified_month_disambiguator>
-CONSTCD14 year_month_weekday_last
+template<class = detail::unspecified_month_disambiguator>
+CONSTCD14
+year_month_weekday_last
 operator-(const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT;
 
 CONSTCD11
-year_month_weekday_last operator-(const year_month_weekday_last& ymwdl,
-                                  const years& dy) NOEXCEPT;
+year_month_weekday_last
+operator-(const year_month_weekday_last& ymwdl, const years& dy) NOEXCEPT;
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os,
-    const year_month_weekday_last& ymwdl);
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last& ymwdl);
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1900)
-inline namespace literals {
+inline namespace literals
+{
 
-CONSTCD11 date::day operator"" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 date::year operator"" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 date::day  operator "" _d(unsigned long long d) NOEXCEPT;
+CONSTCD11 date::year operator "" _y(unsigned long long y) NOEXCEPT;
 
-}  // namespace literals
-#endif  // !defined(_MSC_VER) || (_MSC_VER >= 1900)
+}  // inline namespace literals
+#endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
 
 // CONSTDATA date::month January{1};
 // CONSTDATA date::month February{2};
@@ -1006,16 +993,18 @@ CONSTCD11 date::year operator"" _y(unsigned long long y) NOEXCEPT;
 #if HAS_VOID_T
 
 template <class T, class = std::void_t<>>
-struct is_clock : std::false_type {};
+struct is_clock
+    : std::false_type
+{};
 
 template <class T>
-struct is_clock<T, std::void_t<decltype(T::now()), typename T::rep,
-                               typename T::period, typename T::duration,
-                               typename T::time_point, decltype(T::is_steady)>>
-    : std::true_type {};
+struct is_clock<T, std::void_t<decltype(T::now()), typename T::rep, typename T::period,
+                               typename T::duration, typename T::time_point,
+                               decltype(T::is_steady)>>
+    : std::true_type
+{};
 
-template <class T>
-inline constexpr bool is_clock_v = is_clock<T>::value;
+template<class T> inline constexpr bool is_clock_v = is_clock<T>::value;
 
 #endif  // HAS_VOID_T
 
@@ -1026,760 +1015,974 @@ inline constexpr bool is_clock_v = is_clock<T>::value;
 // utilities
 namespace detail {
 
-template <class CharT, class Traits = std::char_traits<CharT>>
-class save_istream {
- protected:
-  std::basic_ios<CharT, Traits>& is_;
-  CharT fill_;
-  std::ios::fmtflags flags_;
-  std::streamsize precision_;
-  std::streamsize width_;
-  std::basic_ostream<CharT, Traits>* tie_;
-  std::locale loc_;
+template<class CharT, class Traits = std::char_traits<CharT>>
+class save_istream
+{
+protected:
+    std::basic_ios<CharT, Traits>& is_;
+    CharT fill_;
+    std::ios::fmtflags flags_;
+    std::streamsize precision_;
+    std::streamsize width_;
+    std::basic_ostream<CharT, Traits>* tie_;
+    std::locale loc_;
 
- public:
-  ~save_istream() {
-    is_.fill(fill_);
-    is_.flags(flags_);
-    is_.precision(precision_);
-    is_.width(width_);
-    is_.imbue(loc_);
-    is_.tie(tie_);
-  }
+public:
+    ~save_istream()
+    {
+        is_.fill(fill_);
+        is_.flags(flags_);
+        is_.precision(precision_);
+        is_.width(width_);
+        is_.imbue(loc_);
+        is_.tie(tie_);
+    }
 
-  save_istream(const save_istream&) = delete;
-  save_istream& operator=(const save_istream&) = delete;
+    save_istream(const save_istream&) = delete;
+    save_istream& operator=(const save_istream&) = delete;
 
-  explicit save_istream(std::basic_ios<CharT, Traits>& is)
-      : is_(is),
-        fill_(is.fill()),
-        flags_(is.flags()),
-        precision_(is.precision()),
-        width_(is.width(0)),
-        tie_(is.tie(nullptr)),
-        loc_(is.getloc()) {
-    if (tie_ != nullptr) tie_->flush();
-  }
+    explicit save_istream(std::basic_ios<CharT, Traits>& is)
+        : is_(is)
+        , fill_(is.fill())
+        , flags_(is.flags())
+        , precision_(is.precision())
+        , width_(is.width(0))
+        , tie_(is.tie(nullptr))
+        , loc_(is.getloc())
+        {
+            if (tie_ != nullptr)
+                tie_->flush();
+        }
 };
 
-template <class CharT, class Traits = std::char_traits<CharT>>
-class save_ostream : private save_istream<CharT, Traits> {
- public:
-  ~save_ostream() {
-    if ((this->flags_ & std::ios::unitbuf) &&
+template<class CharT, class Traits = std::char_traits<CharT>>
+class save_ostream
+    : private save_istream<CharT, Traits>
+{
+public:
+    ~save_ostream()
+    {
+        if ((this->flags_ & std::ios::unitbuf) &&
 #if HAS_UNCAUGHT_EXCEPTIONS
-        std::uncaught_exceptions() == 0 &&
+                std::uncaught_exceptions() == 0 &&
 #else
-        !std::uncaught_exception() &&
+                !std::uncaught_exception() &&
 #endif
-        this->is_.good())
-      this->is_.rdbuf()->pubsync();
-  }
+                this->is_.good())
+            this->is_.rdbuf()->pubsync();
+    }
 
-  save_ostream(const save_ostream&) = delete;
-  save_ostream& operator=(const save_ostream&) = delete;
+    save_ostream(const save_ostream&) = delete;
+    save_ostream& operator=(const save_ostream&) = delete;
 
-  explicit save_ostream(std::basic_ios<CharT, Traits>& os)
-      : save_istream<CharT, Traits>(os) {}
+    explicit save_ostream(std::basic_ios<CharT, Traits>& os)
+        : save_istream<CharT, Traits>(os)
+        {
+        }
 };
 
 template <class T>
-struct choose_trunc_type {
-  static const int digits = std::numeric_limits<T>::digits;
-  using type = typename std::conditional < digits < 32, std::int32_t,
-        typename std::conditional<digits<64, std::int64_t,
+struct choose_trunc_type
+{
+    static const int digits = std::numeric_limits<T>::digits;
+    using type = typename std::conditional
+                 <
+                     digits < 32,
+                     std::int32_t,
+                     typename std::conditional
+                     <
+                         digits < 64,
+                         std::int64_t,
 #ifdef __SIZEOF_INT128__
-                                         __int128
+                         __int128
 #else
-                                             std::int64_t
+                         std::int64_t
 #endif
-                                         >::type>::type;
+                     >::type
+                 >::type;
 };
 
 template <class T>
-CONSTCD11 inline
-    typename std::enable_if<!std::chrono::treat_as_floating_point<T>::value,
-                            T>::type
-    trunc(T t) NOEXCEPT {
-  return t;
+CONSTCD11
+inline
+typename std::enable_if
+<
+    !std::chrono::treat_as_floating_point<T>::value,
+    T
+>::type
+trunc(T t) NOEXCEPT
+{
+    return t;
 }
 
 template <class T>
-CONSTCD14 inline
-    typename std::enable_if<std::chrono::treat_as_floating_point<T>::value,
-                            T>::type
-    trunc(T t) NOEXCEPT {
-  using std::numeric_limits;
-  using I = typename choose_trunc_type<T>::type;
-  CONSTDATA auto digits = numeric_limits<T>::digits;
-  static_assert(digits < numeric_limits<I>::digits, "");
-  CONSTDATA auto max = I{1} << (digits - 1);
-  CONSTDATA auto min = -max;
-  const auto negative = t < T{0};
-  if (min <= t && t <= max && t != 0 && t == t) {
-    t = static_cast<T>(static_cast<I>(t));
-    if (t == 0 && negative) t = -t;
-  }
-  return t;
+CONSTCD14
+inline
+typename std::enable_if
+<
+    std::chrono::treat_as_floating_point<T>::value,
+    T
+>::type
+trunc(T t) NOEXCEPT
+{
+    using std::numeric_limits;
+    using I = typename choose_trunc_type<T>::type;
+    CONSTDATA auto digits = numeric_limits<T>::digits;
+    static_assert(digits < numeric_limits<I>::digits, "");
+    CONSTDATA auto max = I{1} << (digits-1);
+    CONSTDATA auto min = -max;
+    const auto negative = t < T{0};
+    if (min <= t && t <= max && t != 0 && t == t)
+    {
+        t = static_cast<T>(static_cast<I>(t));
+        if (t == 0 && negative)
+            t = -t;
+    }
+    return t;
 }
 
 template <std::intmax_t Xp, std::intmax_t Yp>
-struct static_gcd {
-  static const std::intmax_t value = static_gcd<Yp, Xp % Yp>::value;
+struct static_gcd
+{
+    static const std::intmax_t value = static_gcd<Yp, Xp % Yp>::value;
 };
 
 template <std::intmax_t Xp>
-struct static_gcd<Xp, 0> {
-  static const std::intmax_t value = Xp;
+struct static_gcd<Xp, 0>
+{
+    static const std::intmax_t value = Xp;
 };
 
 template <>
-struct static_gcd<0, 0> {
-  static const std::intmax_t value = 1;
+struct static_gcd<0, 0>
+{
+    static const std::intmax_t value = 1;
 };
 
 template <class R1, class R2>
-struct no_overflow {
- private:
-  static const std::intmax_t gcd_n1_n2 = static_gcd<R1::num, R2::num>::value;
-  static const std::intmax_t gcd_d1_d2 = static_gcd<R1::den, R2::den>::value;
-  static const std::intmax_t n1 = R1::num / gcd_n1_n2;
-  static const std::intmax_t d1 = R1::den / gcd_d1_d2;
-  static const std::intmax_t n2 = R2::num / gcd_n1_n2;
-  static const std::intmax_t d2 = R2::den / gcd_d1_d2;
+struct no_overflow
+{
+private:
+    static const std::intmax_t gcd_n1_n2 = static_gcd<R1::num, R2::num>::value;
+    static const std::intmax_t gcd_d1_d2 = static_gcd<R1::den, R2::den>::value;
+    static const std::intmax_t n1 = R1::num / gcd_n1_n2;
+    static const std::intmax_t d1 = R1::den / gcd_d1_d2;
+    static const std::intmax_t n2 = R2::num / gcd_n1_n2;
+    static const std::intmax_t d2 = R2::den / gcd_d1_d2;
 #ifdef __cpp_constexpr
-  static const std::intmax_t max = std::numeric_limits<std::intmax_t>::max();
+    static const std::intmax_t max = std::numeric_limits<std::intmax_t>::max();
 #else
-  static const std::intmax_t max = LLONG_MAX;
+    static const std::intmax_t max = LLONG_MAX;
 #endif
 
-  template <std::intmax_t Xp, std::intmax_t Yp, bool overflow>
-  struct mul  // overflow == false
-  {
-    static const std::intmax_t value = Xp * Yp;
-  };
+    template <std::intmax_t Xp, std::intmax_t Yp, bool overflow>
+    struct mul    // overflow == false
+    {
+        static const std::intmax_t value = Xp * Yp;
+    };
 
-  template <std::intmax_t Xp, std::intmax_t Yp>
-  struct mul<Xp, Yp, true> {
-    static const std::intmax_t value = 1;
-  };
+    template <std::intmax_t Xp, std::intmax_t Yp>
+    struct mul<Xp, Yp, true>
+    {
+        static const std::intmax_t value = 1;
+    };
 
- public:
-  static const bool value = (n1 <= max / d2) && (n2 <= max / d1);
-  typedef std::ratio<mul<n1, d2, !value>::value, mul<n2, d1, !value>::value>
-      type;
+public:
+    static const bool value = (n1 <= max / d2) && (n2 <= max / d1);
+    typedef std::ratio<mul<n1, d2, !value>::value,
+                       mul<n2, d1, !value>::value> type;
 };
 
-}  // namespace detail
+}  // detail
 
 // trunc towards zero
 template <class To, class Rep, class Period>
-CONSTCD11 inline typename std::enable_if<
-    detail::no_overflow<Period, typename To::period>::value, To>::type
-trunc(const std::chrono::duration<Rep, Period>& d) {
-  return To{detail::trunc(std::chrono::duration_cast<To>(d).count())};
+CONSTCD11
+inline
+typename std::enable_if
+<
+    detail::no_overflow<Period, typename To::period>::value,
+    To
+>::type
+trunc(const std::chrono::duration<Rep, Period>& d)
+{
+    return To{detail::trunc(std::chrono::duration_cast<To>(d).count())};
 }
 
 template <class To, class Rep, class Period>
-CONSTCD11 inline typename std::enable_if<
-    !detail::no_overflow<Period, typename To::period>::value, To>::type
-trunc(const std::chrono::duration<Rep, Period>& d) {
-  using std::chrono::duration;
-  using std::chrono::duration_cast;
-  using rep = typename std::common_type<Rep, typename To::rep>::type;
-  return To{detail::trunc(
-      duration_cast<To>(duration_cast<duration<rep>>(d)).count())};
+CONSTCD11
+inline
+typename std::enable_if
+<
+    !detail::no_overflow<Period, typename To::period>::value,
+    To
+>::type
+trunc(const std::chrono::duration<Rep, Period>& d)
+{
+    using std::chrono::duration_cast;
+    using std::chrono::duration;
+    using rep = typename std::common_type<Rep, typename To::rep>::type;
+    return To{detail::trunc(duration_cast<To>(duration_cast<duration<rep>>(d)).count())};
 }
 
 #ifndef HAS_CHRONO_ROUNDING
-#if defined(_MSC_FULL_VER) &&      \
-    (_MSC_FULL_VER >= 190023918 || \
-     (_MSC_FULL_VER >= 190000000 && defined(__clang__)))
-#define HAS_CHRONO_ROUNDING 1
-#elif defined(__cpp_lib_chrono) && __cplusplus > 201402 && \
-    __cpp_lib_chrono >= 201510
-#define HAS_CHRONO_ROUNDING 1
-#elif defined(_LIBCPP_VERSION) && __cplusplus > 201402 && \
-    _LIBCPP_VERSION >= 3800
-#define HAS_CHRONO_ROUNDING 1
-#else
-#define HAS_CHRONO_ROUNDING 0
-#endif
+#  if defined(_MSC_FULL_VER) && (_MSC_FULL_VER >= 190023918 || (_MSC_FULL_VER >= 190000000 && defined (__clang__)))
+#    define HAS_CHRONO_ROUNDING 1
+#  elif defined(__cpp_lib_chrono) && __cplusplus > 201402 && __cpp_lib_chrono >= 201510
+#    define HAS_CHRONO_ROUNDING 1
+#  elif defined(_LIBCPP_VERSION) && __cplusplus > 201402 && _LIBCPP_VERSION >= 3800
+#    define HAS_CHRONO_ROUNDING 1
+#  else
+#    define HAS_CHRONO_ROUNDING 0
+#  endif
 #endif  // HAS_CHRONO_ROUNDING
 
 #if HAS_CHRONO_ROUNDING == 0
 
 // round down
 template <class To, class Rep, class Period>
-CONSTCD14 inline typename std::enable_if<
-    detail::no_overflow<Period, typename To::period>::value, To>::type
-floor(const std::chrono::duration<Rep, Period>& d) {
-  auto t = trunc<To>(d);
-  if (t > d) return t - To{1};
-  return t;
+CONSTCD14
+inline
+typename std::enable_if
+<
+    detail::no_overflow<Period, typename To::period>::value,
+    To
+>::type
+floor(const std::chrono::duration<Rep, Period>& d)
+{
+    auto t = trunc<To>(d);
+    if (t > d)
+        return t - To{1};
+    return t;
 }
 
 template <class To, class Rep, class Period>
-CONSTCD14 inline typename std::enable_if<
-    !detail::no_overflow<Period, typename To::period>::value, To>::type
-floor(const std::chrono::duration<Rep, Period>& d) {
-  using rep = typename std::common_type<Rep, typename To::rep>::type;
-  return floor<To>(floor<std::chrono::duration<rep>>(d));
+CONSTCD14
+inline
+typename std::enable_if
+<
+    !detail::no_overflow<Period, typename To::period>::value,
+    To
+>::type
+floor(const std::chrono::duration<Rep, Period>& d)
+{
+    using rep = typename std::common_type<Rep, typename To::rep>::type;
+    return floor<To>(floor<std::chrono::duration<rep>>(d));
 }
 
 // round to nearest, to even on tie
 template <class To, class Rep, class Period>
-CONSTCD14 inline To round(const std::chrono::duration<Rep, Period>& d) {
-  auto t0 = floor<To>(d);
-  auto t1 = t0 + To{1};
-  if (t1 == To{0} && t0 < To{0}) t1 = -t1;
-  auto diff0 = d - t0;
-  auto diff1 = t1 - d;
-  if (diff0 == diff1) {
-    if (t0 - trunc<To>(t0 / 2) * 2 == To{0}) return t0;
+CONSTCD14
+inline
+To
+round(const std::chrono::duration<Rep, Period>& d)
+{
+    auto t0 = floor<To>(d);
+    auto t1 = t0 + To{1};
+    if (t1 == To{0} && t0 < To{0})
+        t1 = -t1;
+    auto diff0 = d - t0;
+    auto diff1 = t1 - d;
+    if (diff0 == diff1)
+    {
+        if (t0 - trunc<To>(t0/2)*2 == To{0})
+            return t0;
+        return t1;
+    }
+    if (diff0 < diff1)
+        return t0;
     return t1;
-  }
-  if (diff0 < diff1) return t0;
-  return t1;
 }
 
 // round up
 template <class To, class Rep, class Period>
-CONSTCD14 inline To ceil(const std::chrono::duration<Rep, Period>& d) {
-  auto t = trunc<To>(d);
-  if (t < d) return t + To{1};
-  return t;
+CONSTCD14
+inline
+To
+ceil(const std::chrono::duration<Rep, Period>& d)
+{
+    auto t = trunc<To>(d);
+    if (t < d)
+        return t + To{1};
+    return t;
 }
 
-template <
-    class Rep, class Period,
-    class = typename std::enable_if<std::numeric_limits<Rep>::is_signed>::type>
-CONSTCD11 std::chrono::duration<Rep, Period> abs(
-    std::chrono::duration<Rep, Period> d) {
-  return d >= d.zero() ? d : -d;
+template <class Rep, class Period,
+          class = typename std::enable_if
+          <
+              std::numeric_limits<Rep>::is_signed
+          >::type>
+CONSTCD11
+std::chrono::duration<Rep, Period>
+abs(std::chrono::duration<Rep, Period> d)
+{
+    return d >= d.zero() ? d : static_cast<decltype(d)>(-d);
 }
 
 // round down
 template <class To, class Clock, class FromDuration>
-CONSTCD11 inline std::chrono::time_point<Clock, To> floor(
-    const std::chrono::time_point<Clock, FromDuration>& tp) {
-  using std::chrono::time_point;
-  return time_point<Clock, To>{date::floor<To>(tp.time_since_epoch())};
+CONSTCD11
+inline
+std::chrono::time_point<Clock, To>
+floor(const std::chrono::time_point<Clock, FromDuration>& tp)
+{
+    using std::chrono::time_point;
+    return time_point<Clock, To>{date::floor<To>(tp.time_since_epoch())};
 }
 
 // round to nearest, to even on tie
 template <class To, class Clock, class FromDuration>
-CONSTCD11 inline std::chrono::time_point<Clock, To> round(
-    const std::chrono::time_point<Clock, FromDuration>& tp) {
-  using std::chrono::time_point;
-  return time_point<Clock, To>{round<To>(tp.time_since_epoch())};
+CONSTCD11
+inline
+std::chrono::time_point<Clock, To>
+round(const std::chrono::time_point<Clock, FromDuration>& tp)
+{
+    using std::chrono::time_point;
+    return time_point<Clock, To>{round<To>(tp.time_since_epoch())};
 }
 
 // round up
 template <class To, class Clock, class FromDuration>
-CONSTCD11 inline std::chrono::time_point<Clock, To> ceil(
-    const std::chrono::time_point<Clock, FromDuration>& tp) {
-  using std::chrono::time_point;
-  return time_point<Clock, To>{ceil<To>(tp.time_since_epoch())};
+CONSTCD11
+inline
+std::chrono::time_point<Clock, To>
+ceil(const std::chrono::time_point<Clock, FromDuration>& tp)
+{
+    using std::chrono::time_point;
+    return time_point<Clock, To>{ceil<To>(tp.time_since_epoch())};
 }
 
 #else  // HAS_CHRONO_ROUNDING == 1
 
-using std::chrono::abs;
-using std::chrono::ceil;
 using std::chrono::floor;
+using std::chrono::ceil;
 using std::chrono::round;
+using std::chrono::abs;
 
 #endif  // HAS_CHRONO_ROUNDING
 
-namespace detail {
+namespace detail
+{
 
 template <class To, class Rep, class Period>
-CONSTCD14 inline typename std::enable_if<
-    !std::chrono::treat_as_floating_point<typename To::rep>::value, To>::type
-round_i(const std::chrono::duration<Rep, Period>& d) {
-  return round<To>(d);
+CONSTCD14
+inline
+typename std::enable_if
+<
+    !std::chrono::treat_as_floating_point<typename To::rep>::value,
+    To
+>::type
+round_i(const std::chrono::duration<Rep, Period>& d)
+{
+    return round<To>(d);
 }
 
 template <class To, class Rep, class Period>
-CONSTCD14 inline typename std::enable_if<
-    std::chrono::treat_as_floating_point<typename To::rep>::value, To>::type
-round_i(const std::chrono::duration<Rep, Period>& d) {
-  return d;
+CONSTCD14
+inline
+typename std::enable_if
+<
+    std::chrono::treat_as_floating_point<typename To::rep>::value,
+    To
+>::type
+round_i(const std::chrono::duration<Rep, Period>& d)
+{
+    return d;
 }
 
 template <class To, class Clock, class FromDuration>
-CONSTCD11 inline std::chrono::time_point<Clock, To> round_i(
-    const std::chrono::time_point<Clock, FromDuration>& tp) {
-  using std::chrono::time_point;
-  return time_point<Clock, To>{round_i<To>(tp.time_since_epoch())};
+CONSTCD11
+inline
+std::chrono::time_point<Clock, To>
+round_i(const std::chrono::time_point<Clock, FromDuration>& tp)
+{
+    using std::chrono::time_point;
+    return time_point<Clock, To>{round_i<To>(tp.time_since_epoch())};
 }
 
-}  // namespace detail
+}  // detail
 
 // trunc towards zero
 template <class To, class Clock, class FromDuration>
-CONSTCD11 inline std::chrono::time_point<Clock, To> trunc(
-    const std::chrono::time_point<Clock, FromDuration>& tp) {
-  using std::chrono::time_point;
-  return time_point<Clock, To>{trunc<To>(tp.time_since_epoch())};
+CONSTCD11
+inline
+std::chrono::time_point<Clock, To>
+trunc(const std::chrono::time_point<Clock, FromDuration>& tp)
+{
+    using std::chrono::time_point;
+    return time_point<Clock, To>{trunc<To>(tp.time_since_epoch())};
 }
 
 // day
 
-CONSTCD11 inline day::day(unsigned d) NOEXCEPT
-    : d_(static_cast<decltype(d_)>(d)) {}
-CONSTCD14 inline day& day::operator++() NOEXCEPT {
-  ++d_;
-  return *this;
-}
-CONSTCD14 inline day day::operator++(int) NOEXCEPT {
-  auto tmp(*this);
-  ++(*this);
-  return tmp;
-}
-CONSTCD14 inline day& day::operator--() NOEXCEPT {
-  --d_;
-  return *this;
-}
-CONSTCD14 inline day day::operator--(int) NOEXCEPT {
-  auto tmp(*this);
-  --(*this);
-  return tmp;
-}
-CONSTCD14 inline day& day::operator+=(const days& d) NOEXCEPT {
-  *this = *this + d;
-  return *this;
-}
-CONSTCD14 inline day& day::operator-=(const days& d) NOEXCEPT {
-  *this = *this - d;
-  return *this;
-}
-CONSTCD11 inline day::operator unsigned() const NOEXCEPT { return d_; }
-CONSTCD11 inline bool day::ok() const NOEXCEPT { return 1 <= d_ && d_ <= 31; }
+CONSTCD11 inline day::day(unsigned d) NOEXCEPT : d_(static_cast<decltype(d_)>(d)) {}
+CONSTCD14 inline day& day::operator++() NOEXCEPT {++d_; return *this;}
+CONSTCD14 inline day day::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
+CONSTCD14 inline day& day::operator--() NOEXCEPT {--d_; return *this;}
+CONSTCD14 inline day day::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
+CONSTCD14 inline day& day::operator+=(const days& d) NOEXCEPT {*this = *this + d; return *this;}
+CONSTCD14 inline day& day::operator-=(const days& d) NOEXCEPT {*this = *this - d; return *this;}
+CONSTCD11 inline day::operator unsigned() const NOEXCEPT {return d_;}
+CONSTCD11 inline bool day::ok() const NOEXCEPT {return 1 <= d_ && d_ <= 31;}
 
 CONSTCD11
-inline bool operator==(const day& x, const day& y) NOEXCEPT {
-  return static_cast<unsigned>(x) == static_cast<unsigned>(y);
+inline
+bool
+operator==(const day& x, const day& y) NOEXCEPT
+{
+    return static_cast<unsigned>(x) == static_cast<unsigned>(y);
 }
 
 CONSTCD11
-inline bool operator!=(const day& x, const day& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const day& x, const day& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const day& x, const day& y) NOEXCEPT {
-  return static_cast<unsigned>(x) < static_cast<unsigned>(y);
+inline
+bool
+operator<(const day& x, const day& y) NOEXCEPT
+{
+    return static_cast<unsigned>(x) < static_cast<unsigned>(y);
 }
 
 CONSTCD11
-inline bool operator>(const day& x, const day& y) NOEXCEPT { return y < x; }
-
-CONSTCD11
-inline bool operator<=(const day& x, const day& y) NOEXCEPT { return !(y < x); }
-
-CONSTCD11
-inline bool operator>=(const day& x, const day& y) NOEXCEPT { return !(x < y); }
-
-CONSTCD11
-inline days operator-(const day& x, const day& y) NOEXCEPT {
-  return days{static_cast<days::rep>(static_cast<unsigned>(x) -
-                                     static_cast<unsigned>(y))};
+inline
+bool
+operator>(const day& x, const day& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline day operator+(const day& x, const days& y) NOEXCEPT {
-  return day{static_cast<unsigned>(x) + static_cast<unsigned>(y.count())};
+inline
+bool
+operator<=(const day& x, const day& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline day operator+(const days& x, const day& y) NOEXCEPT { return y + x; }
+inline
+bool
+operator>=(const day& x, const day& y) NOEXCEPT
+{
+    return !(x < y);
+}
 
 CONSTCD11
-inline day operator-(const day& x, const days& y) NOEXCEPT { return x + -y; }
+inline
+days
+operator-(const day& x, const day& y) NOEXCEPT
+{
+    return days{static_cast<days::rep>(static_cast<unsigned>(x)
+                                     - static_cast<unsigned>(y))};
+}
 
-namespace detail {
+CONSTCD11
+inline
+day
+operator+(const day& x, const days& y) NOEXCEPT
+{
+    return day{static_cast<unsigned>(x) + static_cast<unsigned>(y.count())};
+}
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const day& d) {
-  detail::save_ostream<CharT, Traits> _(os);
-  os.fill('0');
-  os.flags(std::ios::dec | std::ios::right);
-  os.width(2);
-  os << static_cast<unsigned>(d);
-  return os;
+CONSTCD11
+inline
+day
+operator+(const days& x, const day& y) NOEXCEPT
+{
+    return y + x;
+}
+
+CONSTCD11
+inline
+day
+operator-(const day& x, const days& y) NOEXCEPT
+{
+    return x + -y;
+}
+
+namespace detail
+{
+
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const day& d)
+{
+    detail::save_ostream<CharT, Traits> _(os);
+    os.fill('0');
+    os.flags(std::ios::dec | std::ios::right);
+    os.width(2);
+    os << static_cast<unsigned>(d);
+    return os;
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const day& d) {
-  detail::low_level_fmt(os, d);
-  if (!d.ok()) os << " is not a valid day";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const day& d)
+{
+    detail::low_level_fmt(os, d);
+    if (!d.ok())
+        os << " is not a valid day";
+    return os;
 }
 
 // month
 
-CONSTCD11 inline month::month(unsigned m) NOEXCEPT
-    : m_(static_cast<decltype(m_)>(m)) {}
-CONSTCD14 inline month& month::operator++() NOEXCEPT {
-  *this += months{1};
-  return *this;
-}
-CONSTCD14 inline month month::operator++(int) NOEXCEPT {
-  auto tmp(*this);
-  ++(*this);
-  return tmp;
-}
-CONSTCD14 inline month& month::operator--() NOEXCEPT {
-  *this -= months{1};
-  return *this;
-}
-CONSTCD14 inline month month::operator--(int) NOEXCEPT {
-  auto tmp(*this);
-  --(*this);
-  return tmp;
+CONSTCD11 inline month::month(unsigned m) NOEXCEPT : m_(static_cast<decltype(m_)>(m)) {}
+CONSTCD14 inline month& month::operator++() NOEXCEPT {*this += months{1}; return *this;}
+CONSTCD14 inline month month::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
+CONSTCD14 inline month& month::operator--() NOEXCEPT {*this -= months{1}; return *this;}
+CONSTCD14 inline month month::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
+
+CONSTCD14
+inline
+month&
+month::operator+=(const months& m) NOEXCEPT
+{
+    *this = *this + m;
+    return *this;
 }
 
 CONSTCD14
-inline month& month::operator+=(const months& m) NOEXCEPT {
-  *this = *this + m;
-  return *this;
+inline
+month&
+month::operator-=(const months& m) NOEXCEPT
+{
+    *this = *this - m;
+    return *this;
+}
+
+CONSTCD11 inline month::operator unsigned() const NOEXCEPT {return m_;}
+CONSTCD11 inline bool month::ok() const NOEXCEPT {return 1 <= m_ && m_ <= 12;}
+
+CONSTCD11
+inline
+bool
+operator==(const month& x, const month& y) NOEXCEPT
+{
+    return static_cast<unsigned>(x) == static_cast<unsigned>(y);
+}
+
+CONSTCD11
+inline
+bool
+operator!=(const month& x, const month& y) NOEXCEPT
+{
+    return !(x == y);
+}
+
+CONSTCD11
+inline
+bool
+operator<(const month& x, const month& y) NOEXCEPT
+{
+    return static_cast<unsigned>(x) < static_cast<unsigned>(y);
+}
+
+CONSTCD11
+inline
+bool
+operator>(const month& x, const month& y) NOEXCEPT
+{
+    return y < x;
+}
+
+CONSTCD11
+inline
+bool
+operator<=(const month& x, const month& y) NOEXCEPT
+{
+    return !(y < x);
+}
+
+CONSTCD11
+inline
+bool
+operator>=(const month& x, const month& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
 CONSTCD14
-inline month& month::operator-=(const months& m) NOEXCEPT {
-  *this = *this - m;
-  return *this;
-}
-
-CONSTCD11 inline month::operator unsigned() const NOEXCEPT { return m_; }
-CONSTCD11 inline bool month::ok() const NOEXCEPT { return 1 <= m_ && m_ <= 12; }
-
-CONSTCD11
-inline bool operator==(const month& x, const month& y) NOEXCEPT {
-  return static_cast<unsigned>(x) == static_cast<unsigned>(y);
-}
-
-CONSTCD11
-inline bool operator!=(const month& x, const month& y) NOEXCEPT {
-  return !(x == y);
-}
-
-CONSTCD11
-inline bool operator<(const month& x, const month& y) NOEXCEPT {
-  return static_cast<unsigned>(x) < static_cast<unsigned>(y);
-}
-
-CONSTCD11
-inline bool operator>(const month& x, const month& y) NOEXCEPT { return y < x; }
-
-CONSTCD11
-inline bool operator<=(const month& x, const month& y) NOEXCEPT {
-  return !(y < x);
-}
-
-CONSTCD11
-inline bool operator>=(const month& x, const month& y) NOEXCEPT {
-  return !(x < y);
+inline
+months
+operator-(const month& x, const month& y) NOEXCEPT
+{
+    auto const d = static_cast<unsigned>(x) - static_cast<unsigned>(y);
+    return months(d <= 11 ? d : d + 12);
 }
 
 CONSTCD14
-inline months operator-(const month& x, const month& y) NOEXCEPT {
-  auto const d = static_cast<unsigned>(x) - static_cast<unsigned>(y);
-  return months(d <= 11 ? d : d + 12);
+inline
+month
+operator+(const month& x, const months& y) NOEXCEPT
+{
+    auto const mu = static_cast<long long>(static_cast<unsigned>(x)) + y.count() - 1;
+    auto const yr = (mu >= 0 ? mu : mu-11) / 12;
+    return month{static_cast<unsigned>(mu - yr * 12 + 1)};
 }
 
 CONSTCD14
-inline month operator+(const month& x, const months& y) NOEXCEPT {
-  auto const mu =
-      static_cast<long long>(static_cast<unsigned>(x)) + y.count() - 1;
-  auto const yr = (mu >= 0 ? mu : mu - 11) / 12;
-  return month{static_cast<unsigned>(mu - yr * 12 + 1)};
+inline
+month
+operator+(const months& x, const month& y) NOEXCEPT
+{
+    return y + x;
 }
 
 CONSTCD14
-inline month operator+(const months& x, const month& y) NOEXCEPT {
-  return y + x;
+inline
+month
+operator-(const month& x, const months& y) NOEXCEPT
+{
+    return x + -y;
 }
 
-CONSTCD14
-inline month operator-(const month& x, const months& y) NOEXCEPT {
-  return x + -y;
-}
+namespace detail
+{
 
-namespace detail {
-
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const month& m) {
-  if (m.ok()) {
-    CharT fmt[] = {'%', 'b', 0};
-    os << format(os.getloc(), fmt, m);
-  } else
-    os << static_cast<unsigned>(m);
-  return os;
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const month& m)
+{
+    if (m.ok())
+    {
+        CharT fmt[] = {'%', 'b', 0};
+        os << format(os.getloc(), fmt, m);
+    }
+    else
+        os << static_cast<unsigned>(m);
+    return os;
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month& m) {
-  detail::low_level_fmt(os, m);
-  if (!m.ok()) os << " is not a valid month";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month& m)
+{
+    detail::low_level_fmt(os, m);
+    if (!m.ok())
+        os << " is not a valid month";
+    return os;
 }
 
 // year
 
-CONSTCD11 inline year::year(int y) NOEXCEPT : y_(static_cast<decltype(y_)>(y)) {
-}
-CONSTCD14 inline year& year::operator++() NOEXCEPT {
-  ++y_;
-  return *this;
-}
-CONSTCD14 inline year year::operator++(int) NOEXCEPT {
-  auto tmp(*this);
-  ++(*this);
-  return tmp;
-}
-CONSTCD14 inline year& year::operator--() NOEXCEPT {
-  --y_;
-  return *this;
-}
-CONSTCD14 inline year year::operator--(int) NOEXCEPT {
-  auto tmp(*this);
-  --(*this);
-  return tmp;
-}
-CONSTCD14 inline year& year::operator+=(const years& y) NOEXCEPT {
-  *this = *this + y;
-  return *this;
-}
-CONSTCD14 inline year& year::operator-=(const years& y) NOEXCEPT {
-  *this = *this - y;
-  return *this;
-}
-CONSTCD11 inline year year::operator-() const NOEXCEPT { return year{-y_}; }
-CONSTCD11 inline year year::operator+() const NOEXCEPT { return *this; }
+CONSTCD11 inline year::year(int y) NOEXCEPT : y_(static_cast<decltype(y_)>(y)) {}
+CONSTCD14 inline year& year::operator++() NOEXCEPT {++y_; return *this;}
+CONSTCD14 inline year year::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
+CONSTCD14 inline year& year::operator--() NOEXCEPT {--y_; return *this;}
+CONSTCD14 inline year year::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
+CONSTCD14 inline year& year::operator+=(const years& y) NOEXCEPT {*this = *this + y; return *this;}
+CONSTCD14 inline year& year::operator-=(const years& y) NOEXCEPT {*this = *this - y; return *this;}
+CONSTCD11 inline year year::operator-() const NOEXCEPT {return year{-y_};}
+CONSTCD11 inline year year::operator+() const NOEXCEPT {return *this;}
 
 CONSTCD11
-inline bool year::is_leap() const NOEXCEPT {
-  return y_ % 4 == 0 && (y_ % 100 != 0 || y_ % 400 == 0);
+inline
+bool
+year::is_leap() const NOEXCEPT
+{
+    return y_ % 4 == 0 && (y_ % 100 != 0 || y_ % 400 == 0);
 }
 
-CONSTCD11 inline year::operator int() const NOEXCEPT { return y_; }
+CONSTCD11 inline year::operator int() const NOEXCEPT {return y_;}
 
 CONSTCD11
-inline bool year::ok() const NOEXCEPT {
-  return y_ != std::numeric_limits<short>::min();
+inline
+bool
+year::ok() const NOEXCEPT
+{
+    return y_ != std::numeric_limits<short>::min();
 }
 
 CONSTCD11
-inline bool operator==(const year& x, const year& y) NOEXCEPT {
-  return static_cast<int>(x) == static_cast<int>(y);
+inline
+bool
+operator==(const year& x, const year& y) NOEXCEPT
+{
+    return static_cast<int>(x) == static_cast<int>(y);
 }
 
 CONSTCD11
-inline bool operator!=(const year& x, const year& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const year& x, const year& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const year& x, const year& y) NOEXCEPT {
-  return static_cast<int>(x) < static_cast<int>(y);
+inline
+bool
+operator<(const year& x, const year& y) NOEXCEPT
+{
+    return static_cast<int>(x) < static_cast<int>(y);
 }
 
 CONSTCD11
-inline bool operator>(const year& x, const year& y) NOEXCEPT { return y < x; }
-
-CONSTCD11
-inline bool operator<=(const year& x, const year& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator>(const year& x, const year& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator>=(const year& x, const year& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator<=(const year& x, const year& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline years operator-(const year& x, const year& y) NOEXCEPT {
-  return years{static_cast<int>(x) - static_cast<int>(y)};
+inline
+bool
+operator>=(const year& x, const year& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
 CONSTCD11
-inline year operator+(const year& x, const years& y) NOEXCEPT {
-  return year{static_cast<int>(x) + y.count()};
+inline
+years
+operator-(const year& x, const year& y) NOEXCEPT
+{
+    return years{static_cast<int>(x) - static_cast<int>(y)};
 }
 
 CONSTCD11
-inline year operator+(const years& x, const year& y) NOEXCEPT { return y + x; }
-
-CONSTCD11
-inline year operator-(const year& x, const years& y) NOEXCEPT {
-  return year{static_cast<int>(x) - y.count()};
+inline
+year
+operator+(const year& x, const years& y) NOEXCEPT
+{
+    return year{static_cast<int>(x) + y.count()};
 }
 
-namespace detail {
+CONSTCD11
+inline
+year
+operator+(const years& x, const year& y) NOEXCEPT
+{
+    return y + x;
+}
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const year& y) {
-  detail::save_ostream<CharT, Traits> _(os);
-  os.fill('0');
-  os.flags(std::ios::dec | std::ios::internal);
-  os.width(4 + (y < year{0}));
-  os.imbue(std::locale::classic());
-  os << static_cast<int>(y);
-  return os;
+CONSTCD11
+inline
+year
+operator-(const year& x, const years& y) NOEXCEPT
+{
+    return year{static_cast<int>(x) - y.count()};
+}
+
+namespace detail
+{
+
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const year& y)
+{
+    detail::save_ostream<CharT, Traits> _(os);
+    os.fill('0');
+    os.flags(std::ios::dec | std::ios::internal);
+    os.width(4 + (y < year{0}));
+    os.imbue(std::locale::classic());
+    os << static_cast<int>(y);
+    return os;
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year& y) {
-  detail::low_level_fmt(os, y);
-  if (!y.ok()) os << " is not a valid year";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
+{
+    detail::low_level_fmt(os, y);
+    if (!y.ok())
+        os << " is not a valid year";
+    return os;
 }
 
 // weekday
 
 CONSTCD14
-inline unsigned char weekday::weekday_from_days(int z) NOEXCEPT {
-  auto u = static_cast<unsigned>(z);
-  return static_cast<unsigned char>(z >= -4 ? (u + 4) % 7 : u % 7);
+inline
+unsigned char
+weekday::weekday_from_days(int z) NOEXCEPT
+{
+    auto u = static_cast<unsigned>(z);
+    return static_cast<unsigned char>(z >= -4 ? (u+4) % 7 : u % 7);
 }
 
 CONSTCD11
-inline weekday::weekday(unsigned wd) NOEXCEPT
-    : wd_(static_cast<decltype(wd_)>(wd != 7 ? wd : 0)) {}
+inline
+weekday::weekday(unsigned wd) NOEXCEPT
+    : wd_(static_cast<decltype(wd_)>(wd != 7 ? wd : 0))
+    {}
 
 CONSTCD14
-inline weekday::weekday(const sys_days& dp) NOEXCEPT
-    : wd_(weekday_from_days(dp.time_since_epoch().count())) {}
+inline
+weekday::weekday(const sys_days& dp) NOEXCEPT
+    : wd_(weekday_from_days(dp.time_since_epoch().count()))
+    {}
 
 CONSTCD14
-inline weekday::weekday(const local_days& dp) NOEXCEPT
-    : wd_(weekday_from_days(dp.time_since_epoch().count())) {}
+inline
+weekday::weekday(const local_days& dp) NOEXCEPT
+    : wd_(weekday_from_days(dp.time_since_epoch().count()))
+    {}
 
-CONSTCD14 inline weekday& weekday::operator++() NOEXCEPT {
-  *this += days{1};
-  return *this;
-}
-CONSTCD14 inline weekday weekday::operator++(int) NOEXCEPT {
-  auto tmp(*this);
-  ++(*this);
-  return tmp;
-}
-CONSTCD14 inline weekday& weekday::operator--() NOEXCEPT {
-  *this -= days{1};
-  return *this;
-}
-CONSTCD14 inline weekday weekday::operator--(int) NOEXCEPT {
-  auto tmp(*this);
-  --(*this);
-  return tmp;
-}
+CONSTCD14 inline weekday& weekday::operator++() NOEXCEPT {*this += days{1}; return *this;}
+CONSTCD14 inline weekday weekday::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
+CONSTCD14 inline weekday& weekday::operator--() NOEXCEPT {*this -= days{1}; return *this;}
+CONSTCD14 inline weekday weekday::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
 
 CONSTCD14
-inline weekday& weekday::operator+=(const days& d) NOEXCEPT {
-  *this = *this + d;
-  return *this;
+inline
+weekday&
+weekday::operator+=(const days& d) NOEXCEPT
+{
+    *this = *this + d;
+    return *this;
 }
 
 CONSTCD14
-inline weekday& weekday::operator-=(const days& d) NOEXCEPT {
-  *this = *this - d;
-  return *this;
+inline
+weekday&
+weekday::operator-=(const days& d) NOEXCEPT
+{
+    *this = *this - d;
+    return *this;
 }
 
-CONSTCD11 inline bool weekday::ok() const NOEXCEPT { return wd_ <= 6; }
+CONSTCD11 inline bool weekday::ok() const NOEXCEPT {return wd_ <= 6;}
 
 CONSTCD11
-inline unsigned weekday::c_encoding() const NOEXCEPT { return unsigned{wd_}; }
-
-CONSTCD11
-inline unsigned weekday::iso_encoding() const NOEXCEPT {
-  return unsigned{((wd_ == 0u) ? 7u : wd_)};
+inline
+unsigned weekday::c_encoding() const NOEXCEPT
+{
+    return unsigned{wd_};
 }
 
 CONSTCD11
-inline bool operator==(const weekday& x, const weekday& y) NOEXCEPT {
-  return x.wd_ == y.wd_;
+inline
+unsigned weekday::iso_encoding() const NOEXCEPT
+{
+    return unsigned{((wd_ == 0u) ? 7u : wd_)};
 }
 
 CONSTCD11
-inline bool operator!=(const weekday& x, const weekday& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator==(const weekday& x, const weekday& y) NOEXCEPT
+{
+    return x.wd_ == y.wd_;
+}
+
+CONSTCD11
+inline
+bool
+operator!=(const weekday& x, const weekday& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD14
-inline days operator-(const weekday& x, const weekday& y) NOEXCEPT {
-  auto const wdu = x.wd_ - y.wd_;
-  auto const wk = (wdu >= 0 ? wdu : wdu - 6) / 7;
-  return days{wdu - wk * 7};
+inline
+days
+operator-(const weekday& x, const weekday& y) NOEXCEPT
+{
+    auto const wdu = x.wd_ - y.wd_;
+    auto const wk = (wdu >= 0 ? wdu : wdu-6) / 7;
+    return days{wdu - wk * 7};
 }
 
 CONSTCD14
-inline weekday operator+(const weekday& x, const days& y) NOEXCEPT {
-  auto const wdu =
-      static_cast<long long>(static_cast<unsigned>(x.wd_)) + y.count();
-  auto const wk = (wdu >= 0 ? wdu : wdu - 6) / 7;
-  return weekday{static_cast<unsigned>(wdu - wk * 7)};
+inline
+weekday
+operator+(const weekday& x, const days& y) NOEXCEPT
+{
+    auto const wdu = static_cast<long long>(static_cast<unsigned>(x.wd_)) + y.count();
+    auto const wk = (wdu >= 0 ? wdu : wdu-6) / 7;
+    return weekday{static_cast<unsigned>(wdu - wk * 7)};
 }
 
 CONSTCD14
-inline weekday operator+(const days& x, const weekday& y) NOEXCEPT {
-  return y + x;
+inline
+weekday
+operator+(const days& x, const weekday& y) NOEXCEPT
+{
+    return y + x;
 }
 
 CONSTCD14
-inline weekday operator-(const weekday& x, const days& y) NOEXCEPT {
-  return x + -y;
+inline
+weekday
+operator-(const weekday& x, const days& y) NOEXCEPT
+{
+    return x + -y;
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const weekday& wd) {
-  if (wd.ok()) {
-    CharT fmt[] = {'%', 'a', 0};
-    os << format(fmt, wd);
-  } else
-    os << wd.c_encoding();
-  return os;
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const weekday& wd)
+{
+    if (wd.ok())
+    {
+        CharT fmt[] = {'%', 'a', 0};
+        os << format(fmt, wd);
+    }
+    else
+        os << wd.c_encoding();
+    return os;
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday& wd) {
-  detail::low_level_fmt(os, wd);
-  if (!wd.ok()) os << " is not a valid weekday";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday& wd)
+{
+    detail::low_level_fmt(os, wd);
+    if (!wd.ok())
+        os << " is not a valid weekday";
+    return os;
 }
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1900)
-inline namespace literals {
+inline namespace literals
+{
 
 CONSTCD11
-inline date::day operator"" _d(unsigned long long d) NOEXCEPT {
-  return date::day{static_cast<unsigned>(d)};
+inline
+date::day
+operator "" _d(unsigned long long d) NOEXCEPT
+{
+    return date::day{static_cast<unsigned>(d)};
 }
 
 CONSTCD11
-inline date::year operator"" _y(unsigned long long y) NOEXCEPT {
-  return date::year(static_cast<int>(y));
+inline
+date::year
+operator "" _y(unsigned long long y) NOEXCEPT
+{
+    return date::year(static_cast<int>(y));
 }
 #endif  // !defined(_MSC_VER) || (_MSC_VER >= 1900)
 
@@ -1834,1391 +2037,1875 @@ CONSTDATA date::weekday Sunday{7};
 // weekday_indexed
 
 CONSTCD11
-inline weekday weekday_indexed::weekday() const NOEXCEPT {
-  return date::weekday{static_cast<unsigned>(wd_)};
+inline
+weekday
+weekday_indexed::weekday() const NOEXCEPT
+{
+    return date::weekday{static_cast<unsigned>(wd_)};
 }
 
-CONSTCD11 inline unsigned weekday_indexed::index() const NOEXCEPT {
-  return index_;
-}
+CONSTCD11 inline unsigned weekday_indexed::index() const NOEXCEPT {return index_;}
 
 CONSTCD11
-inline bool weekday_indexed::ok() const NOEXCEPT {
-  return weekday().ok() && 1 <= index_ && index_ <= 5;
+inline
+bool
+weekday_indexed::ok() const NOEXCEPT
+{
+    return weekday().ok() && 1 <= index_ && index_ <= 5;
 }
 
 #ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wconversion"
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wconversion"
 #endif  // __GNUC__
 
 CONSTCD11
-inline weekday_indexed::weekday_indexed(const date::weekday& wd,
-                                        unsigned index) NOEXCEPT
-    : wd_(static_cast<decltype(wd_)>(static_cast<unsigned>(wd.wd_))),
-      index_(static_cast<decltype(index_)>(index)) {}
+inline
+weekday_indexed::weekday_indexed(const date::weekday& wd, unsigned index) NOEXCEPT
+    : wd_(static_cast<decltype(wd_)>(static_cast<unsigned>(wd.wd_)))
+    , index_(static_cast<decltype(index_)>(index))
+    {}
 
 #ifdef __GNUC__
-#pragma GCC diagnostic pop
+#  pragma GCC diagnostic pop
 #endif  // __GNUC__
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi) {
-  return low_level_fmt(os, wdi.weekday()) << '[' << wdi.index() << ']';
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi)
+{
+    return low_level_fmt(os, wdi.weekday()) << '[' << wdi.index() << ']';
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi) {
-  detail::low_level_fmt(os, wdi);
-  if (!wdi.ok()) os << " is not a valid weekday_indexed";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday_indexed& wdi)
+{
+    detail::low_level_fmt(os, wdi);
+    if (!wdi.ok())
+        os << " is not a valid weekday_indexed";
+    return os;
 }
 
 CONSTCD11
-inline weekday_indexed weekday::operator[](unsigned index) const NOEXCEPT {
-  return {*this, index};
+inline
+weekday_indexed
+weekday::operator[](unsigned index) const NOEXCEPT
+{
+    return {*this, index};
 }
 
 CONSTCD11
-inline bool operator==(const weekday_indexed& x,
-                       const weekday_indexed& y) NOEXCEPT {
-  return x.weekday() == y.weekday() && x.index() == y.index();
+inline
+bool
+operator==(const weekday_indexed& x, const weekday_indexed& y) NOEXCEPT
+{
+    return x.weekday() == y.weekday() && x.index() == y.index();
 }
 
 CONSTCD11
-inline bool operator!=(const weekday_indexed& x,
-                       const weekday_indexed& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const weekday_indexed& x, const weekday_indexed& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 // weekday_last
 
-CONSTCD11 inline date::weekday weekday_last::weekday() const NOEXCEPT {
-  return wd_;
-}
-CONSTCD11 inline bool weekday_last::ok() const NOEXCEPT { return wd_.ok(); }
-CONSTCD11 inline weekday_last::weekday_last(const date::weekday& wd) NOEXCEPT
-    : wd_(wd) {}
+CONSTCD11 inline date::weekday weekday_last::weekday() const NOEXCEPT {return wd_;}
+CONSTCD11 inline bool weekday_last::ok() const NOEXCEPT {return wd_.ok();}
+CONSTCD11 inline weekday_last::weekday_last(const date::weekday& wd) NOEXCEPT : wd_(wd) {}
 
 CONSTCD11
-inline bool operator==(const weekday_last& x, const weekday_last& y) NOEXCEPT {
-  return x.weekday() == y.weekday();
+inline
+bool
+operator==(const weekday_last& x, const weekday_last& y) NOEXCEPT
+{
+    return x.weekday() == y.weekday();
 }
 
 CONSTCD11
-inline bool operator!=(const weekday_last& x, const weekday_last& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const weekday_last& x, const weekday_last& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl) {
-  return low_level_fmt(os, wdl.weekday()) << "[last]";
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl)
+{
+    return low_level_fmt(os, wdl.weekday()) << "[last]";
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl) {
-  detail::low_level_fmt(os, wdl);
-  if (!wdl.ok()) os << " is not a valid weekday_last";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const weekday_last& wdl)
+{
+    detail::low_level_fmt(os, wdl);
+    if (!wdl.ok())
+        os << " is not a valid weekday_last";
+    return os;
 }
 
 CONSTCD11
-inline weekday_last weekday::operator[](last_spec) const NOEXCEPT {
-  return weekday_last{*this};
+inline
+weekday_last
+weekday::operator[](last_spec) const NOEXCEPT
+{
+    return weekday_last{*this};
 }
 
 // year_month
 
 CONSTCD11
-inline year_month::year_month(const date::year& y,
-                              const date::month& m) NOEXCEPT : y_(y),
-                                                               m_(m) {}
+inline
+year_month::year_month(const date::year& y, const date::month& m) NOEXCEPT
+    : y_(y)
+    , m_(m)
+    {}
 
-CONSTCD11 inline year year_month::year() const NOEXCEPT { return y_; }
-CONSTCD11 inline month year_month::month() const NOEXCEPT { return m_; }
-CONSTCD11 inline bool year_month::ok() const NOEXCEPT {
-  return y_.ok() && m_.ok();
+CONSTCD11 inline year year_month::year() const NOEXCEPT {return y_;}
+CONSTCD11 inline month year_month::month() const NOEXCEPT {return m_;}
+CONSTCD11 inline bool year_month::ok() const NOEXCEPT {return y_.ok() && m_.ok();}
+
+template<class>
+CONSTCD14
+inline
+year_month&
+year_month::operator+=(const months& dm) NOEXCEPT
+{
+    *this = *this + dm;
+    return *this;
 }
 
-template <class>
-CONSTCD14 inline year_month& year_month::operator+=(const months& dm) NOEXCEPT {
-  *this = *this + dm;
-  return *this;
-}
-
-template <class>
-CONSTCD14 inline year_month& year_month::operator-=(const months& dm) NOEXCEPT {
-  *this = *this - dm;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month&
+year_month::operator-=(const months& dm) NOEXCEPT
+{
+    *this = *this - dm;
+    return *this;
 }
 
 CONSTCD14
-inline year_month& year_month::operator+=(const years& dy) NOEXCEPT {
-  *this = *this + dy;
-  return *this;
+inline
+year_month&
+year_month::operator+=(const years& dy) NOEXCEPT
+{
+    *this = *this + dy;
+    return *this;
 }
 
 CONSTCD14
-inline year_month& year_month::operator-=(const years& dy) NOEXCEPT {
-  *this = *this - dy;
-  return *this;
+inline
+year_month&
+year_month::operator-=(const years& dy) NOEXCEPT
+{
+    *this = *this - dy;
+    return *this;
 }
 
 CONSTCD11
-inline bool operator==(const year_month& x, const year_month& y) NOEXCEPT {
-  return x.year() == y.year() && x.month() == y.month();
+inline
+bool
+operator==(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return x.year() == y.year() && x.month() == y.month();
 }
 
 CONSTCD11
-inline bool operator!=(const year_month& x, const year_month& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const year_month& x, const year_month& y) NOEXCEPT {
-  return x.year() < y.year()
-             ? true
-             : (x.year() > y.year() ? false : (x.month() < y.month()));
+inline
+bool
+operator<(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return x.year() < y.year() ? true
+        : (x.year() > y.year() ? false
+        : (x.month() < y.month()));
 }
 
 CONSTCD11
-inline bool operator>(const year_month& x, const year_month& y) NOEXCEPT {
-  return y < x;
+inline
+bool
+operator>(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator<=(const year_month& x, const year_month& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator<=(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline bool operator>=(const year_month& x, const year_month& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator>=(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
-template <class>
-CONSTCD14 inline year_month operator+(const year_month& ym,
-                                      const months& dm) NOEXCEPT {
-  auto dmi =
-      static_cast<int>(static_cast<unsigned>(ym.month())) - 1 + dm.count();
-  auto dy = (dmi >= 0 ? dmi : dmi - 11) / 12;
-  dmi = dmi - dy * 12 + 1;
-  return (ym.year() + years(dy)) / month(static_cast<unsigned>(dmi));
+template<class>
+CONSTCD14
+inline
+year_month
+operator+(const year_month& ym, const months& dm) NOEXCEPT
+{
+    auto dmi = static_cast<int>(static_cast<unsigned>(ym.month())) - 1 + dm.count();
+    auto dy = (dmi >= 0 ? dmi : dmi-11) / 12;
+    dmi = dmi - dy * 12 + 1;
+    return (ym.year() + years(dy)) / month(static_cast<unsigned>(dmi));
 }
 
-template <class>
-CONSTCD14 inline year_month operator+(const months& dm,
-                                      const year_month& ym) NOEXCEPT {
-  return ym + dm;
+template<class>
+CONSTCD14
+inline
+year_month
+operator+(const months& dm, const year_month& ym) NOEXCEPT
+{
+    return ym + dm;
 }
 
-template <class>
-CONSTCD14 inline year_month operator-(const year_month& ym,
-                                      const months& dm) NOEXCEPT {
-  return ym + -dm;
-}
-
-CONSTCD11
-inline months operator-(const year_month& x, const year_month& y) NOEXCEPT {
-  return (x.year() - y.year()) + months(static_cast<unsigned>(x.month()) -
-                                        static_cast<unsigned>(y.month()));
-}
-
-CONSTCD11
-inline year_month operator+(const year_month& ym, const years& dy) NOEXCEPT {
-  return (ym.year() + dy) / ym.month();
-}
-
-CONSTCD11
-inline year_month operator+(const years& dy, const year_month& ym) NOEXCEPT {
-  return ym + dy;
+template<class>
+CONSTCD14
+inline
+year_month
+operator-(const year_month& ym, const months& dm) NOEXCEPT
+{
+    return ym + -dm;
 }
 
 CONSTCD11
-inline year_month operator-(const year_month& ym, const years& dy) NOEXCEPT {
-  return ym + -dy;
+inline
+months
+operator-(const year_month& x, const year_month& y) NOEXCEPT
+{
+    return (x.year() - y.year()) +
+            months(static_cast<unsigned>(x.month()) - static_cast<unsigned>(y.month()));
 }
 
-namespace detail {
+CONSTCD11
+inline
+year_month
+operator+(const year_month& ym, const years& dy) NOEXCEPT
+{
+    return (ym.year() + dy) / ym.month();
+}
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const year_month& ym) {
-  low_level_fmt(os, ym.year()) << '/';
-  return low_level_fmt(os, ym.month());
+CONSTCD11
+inline
+year_month
+operator+(const years& dy, const year_month& ym) NOEXCEPT
+{
+    return ym + dy;
+}
+
+CONSTCD11
+inline
+year_month
+operator-(const year_month& ym, const years& dy) NOEXCEPT
+{
+    return ym + -dy;
+}
+
+namespace detail
+{
+
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const year_month& ym)
+{
+    low_level_fmt(os, ym.year()) << '/';
+    return low_level_fmt(os, ym.month());
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month& ym) {
-  detail::low_level_fmt(os, ym);
-  if (!ym.ok()) os << " is not a valid year_month";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month& ym)
+{
+    detail::low_level_fmt(os, ym);
+    if (!ym.ok())
+        os << " is not a valid year_month";
+    return os;
 }
 
 // month_day
 
 CONSTCD11
-inline month_day::month_day(const date::month& m, const date::day& d) NOEXCEPT
-    : m_(m),
-      d_(d) {}
+inline
+month_day::month_day(const date::month& m, const date::day& d) NOEXCEPT
+    : m_(m)
+    , d_(d)
+    {}
 
-CONSTCD11 inline date::month month_day::month() const NOEXCEPT { return m_; }
-CONSTCD11 inline date::day month_day::day() const NOEXCEPT { return d_; }
+CONSTCD11 inline date::month month_day::month() const NOEXCEPT {return m_;}
+CONSTCD11 inline date::day month_day::day() const NOEXCEPT {return d_;}
 
 CONSTCD14
-inline bool month_day::ok() const NOEXCEPT {
-  CONSTDATA date::day d[] = {date::day(31), date::day(29), date::day(31),
-                             date::day(30), date::day(31), date::day(30),
-                             date::day(31), date::day(31), date::day(30),
-                             date::day(31), date::day(30), date::day(31)};
-  return m_.ok() && date::day{1} <= d_ &&
-         d_ <= d[static_cast<unsigned>(m_) - 1];
+inline
+bool
+month_day::ok() const NOEXCEPT
+{
+    CONSTDATA date::day d[] =
+    {
+        date::day(31), date::day(29), date::day(31),
+        date::day(30), date::day(31), date::day(30),
+        date::day(31), date::day(31), date::day(30),
+        date::day(31), date::day(30), date::day(31)
+    };
+    return m_.ok() && date::day{1} <= d_ && d_ <= d[static_cast<unsigned>(m_)-1];
 }
 
 CONSTCD11
-inline bool operator==(const month_day& x, const month_day& y) NOEXCEPT {
-  return x.month() == y.month() && x.day() == y.day();
+inline
+bool
+operator==(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return x.month() == y.month() && x.day() == y.day();
 }
 
 CONSTCD11
-inline bool operator!=(const month_day& x, const month_day& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const month_day& x, const month_day& y) NOEXCEPT {
-  return x.month() < y.month()
-             ? true
-             : (x.month() > y.month() ? false : (x.day() < y.day()));
+inline
+bool
+operator<(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return x.month() < y.month() ? true
+        : (x.month() > y.month() ? false
+        : (x.day() < y.day()));
 }
 
 CONSTCD11
-inline bool operator>(const month_day& x, const month_day& y) NOEXCEPT {
-  return y < x;
+inline
+bool
+operator>(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator<=(const month_day& x, const month_day& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator<=(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline bool operator>=(const month_day& x, const month_day& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator>=(const month_day& x, const month_day& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const month_day& md) {
-  low_level_fmt(os, md.month()) << '/';
-  return low_level_fmt(os, md.day());
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const month_day& md)
+{
+    low_level_fmt(os, md.month()) << '/';
+    return low_level_fmt(os, md.day());
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_day& md) {
-  detail::low_level_fmt(os, md);
-  if (!md.ok()) os << " is not a valid month_day";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_day& md)
+{
+    detail::low_level_fmt(os, md);
+    if (!md.ok())
+        os << " is not a valid month_day";
+    return os;
 }
 
 // month_day_last
 
-CONSTCD11 inline month month_day_last::month() const NOEXCEPT { return m_; }
-CONSTCD11 inline bool month_day_last::ok() const NOEXCEPT { return m_.ok(); }
-CONSTCD11 inline month_day_last::month_day_last(const date::month& m) NOEXCEPT
-    : m_(m) {}
+CONSTCD11 inline month month_day_last::month() const NOEXCEPT {return m_;}
+CONSTCD11 inline bool month_day_last::ok() const NOEXCEPT {return m_.ok();}
+CONSTCD11 inline month_day_last::month_day_last(const date::month& m) NOEXCEPT : m_(m) {}
 
 CONSTCD11
-inline bool operator==(const month_day_last& x,
-                       const month_day_last& y) NOEXCEPT {
-  return x.month() == y.month();
+inline
+bool
+operator==(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return x.month() == y.month();
 }
 
 CONSTCD11
-inline bool operator!=(const month_day_last& x,
-                       const month_day_last& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const month_day_last& x,
-                      const month_day_last& y) NOEXCEPT {
-  return x.month() < y.month();
+inline
+bool
+operator<(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return x.month() < y.month();
 }
 
 CONSTCD11
-inline bool operator>(const month_day_last& x,
-                      const month_day_last& y) NOEXCEPT {
-  return y < x;
+inline
+bool
+operator>(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator<=(const month_day_last& x,
-                       const month_day_last& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator<=(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline bool operator>=(const month_day_last& x,
-                       const month_day_last& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator>=(const month_day_last& x, const month_day_last& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl) {
-  return low_level_fmt(os, mdl.month()) << "/last";
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl)
+{
+    return low_level_fmt(os, mdl.month()) << "/last";
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl) {
-  detail::low_level_fmt(os, mdl);
-  if (!mdl.ok()) os << " is not a valid month_day_last";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_day_last& mdl)
+{
+    detail::low_level_fmt(os, mdl);
+    if (!mdl.ok())
+        os << " is not a valid month_day_last";
+    return os;
 }
 
 // month_weekday
 
 CONSTCD11
-inline month_weekday::month_weekday(const date::month& m,
-                                    const date::weekday_indexed& wdi) NOEXCEPT
-    : m_(m),
-      wdi_(wdi) {}
+inline
+month_weekday::month_weekday(const date::month& m,
+                             const date::weekday_indexed& wdi) NOEXCEPT
+    : m_(m)
+    , wdi_(wdi)
+    {}
 
-CONSTCD11 inline month month_weekday::month() const NOEXCEPT { return m_; }
+CONSTCD11 inline month month_weekday::month() const NOEXCEPT {return m_;}
 
 CONSTCD11
-inline weekday_indexed month_weekday::weekday_indexed() const NOEXCEPT {
-  return wdi_;
+inline
+weekday_indexed
+month_weekday::weekday_indexed() const NOEXCEPT
+{
+    return wdi_;
 }
 
 CONSTCD11
-inline bool month_weekday::ok() const NOEXCEPT { return m_.ok() && wdi_.ok(); }
-
-CONSTCD11
-inline bool operator==(const month_weekday& x,
-                       const month_weekday& y) NOEXCEPT {
-  return x.month() == y.month() && x.weekday_indexed() == y.weekday_indexed();
+inline
+bool
+month_weekday::ok() const NOEXCEPT
+{
+    return m_.ok() && wdi_.ok();
 }
 
 CONSTCD11
-inline bool operator!=(const month_weekday& x,
-                       const month_weekday& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator==(const month_weekday& x, const month_weekday& y) NOEXCEPT
+{
+    return x.month() == y.month() && x.weekday_indexed() == y.weekday_indexed();
 }
 
-namespace detail {
+CONSTCD11
+inline
+bool
+operator!=(const month_weekday& x, const month_weekday& y) NOEXCEPT
+{
+    return !(x == y);
+}
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd) {
-  low_level_fmt(os, mwd.month()) << '/';
-  return low_level_fmt(os, mwd.weekday_indexed());
+namespace detail
+{
+
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd)
+{
+    low_level_fmt(os, mwd.month()) << '/';
+    return low_level_fmt(os, mwd.weekday_indexed());
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd) {
-  detail::low_level_fmt(os, mwd);
-  if (!mwd.ok()) os << " is not a valid month_weekday";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_weekday& mwd)
+{
+    detail::low_level_fmt(os, mwd);
+    if (!mwd.ok())
+        os << " is not a valid month_weekday";
+    return os;
 }
 
 // month_weekday_last
 
 CONSTCD11
-inline month_weekday_last::month_weekday_last(
-    const date::month& m, const date::weekday_last& wdl) NOEXCEPT : m_(m),
-                                                                    wdl_(wdl) {}
+inline
+month_weekday_last::month_weekday_last(const date::month& m,
+                                       const date::weekday_last& wdl) NOEXCEPT
+    : m_(m)
+    , wdl_(wdl)
+    {}
 
-CONSTCD11 inline month month_weekday_last::month() const NOEXCEPT { return m_; }
+CONSTCD11 inline month month_weekday_last::month() const NOEXCEPT {return m_;}
 
 CONSTCD11
-inline weekday_last month_weekday_last::weekday_last() const NOEXCEPT {
-  return wdl_;
+inline
+weekday_last
+month_weekday_last::weekday_last() const NOEXCEPT
+{
+    return wdl_;
 }
 
 CONSTCD11
-inline bool month_weekday_last::ok() const NOEXCEPT {
-  return m_.ok() && wdl_.ok();
+inline
+bool
+month_weekday_last::ok() const NOEXCEPT
+{
+    return m_.ok() && wdl_.ok();
 }
 
 CONSTCD11
-inline bool operator==(const month_weekday_last& x,
-                       const month_weekday_last& y) NOEXCEPT {
-  return x.month() == y.month() && x.weekday_last() == y.weekday_last();
+inline
+bool
+operator==(const month_weekday_last& x, const month_weekday_last& y) NOEXCEPT
+{
+    return x.month() == y.month() && x.weekday_last() == y.weekday_last();
 }
 
 CONSTCD11
-inline bool operator!=(const month_weekday_last& x,
-                       const month_weekday_last& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const month_weekday_last& x, const month_weekday_last& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl) {
-  low_level_fmt(os, mwdl.month()) << '/';
-  return low_level_fmt(os, mwdl.weekday_last());
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl)
+{
+    low_level_fmt(os, mwdl.month()) << '/';
+    return low_level_fmt(os, mwdl.weekday_last());
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl) {
-  detail::low_level_fmt(os, mwdl);
-  if (!mwdl.ok()) os << " is not a valid month_weekday_last";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const month_weekday_last& mwdl)
+{
+    detail::low_level_fmt(os, mwdl);
+    if (!mwdl.ok())
+        os << " is not a valid month_weekday_last";
+    return os;
 }
 
 // year_month_day_last
 
 CONSTCD11
-inline year_month_day_last::year_month_day_last(
-    const date::year& y, const date::month_day_last& mdl) NOEXCEPT : y_(y),
-                                                                     mdl_(mdl) {
+inline
+year_month_day_last::year_month_day_last(const date::year& y,
+                                         const date::month_day_last& mdl) NOEXCEPT
+    : y_(y)
+    , mdl_(mdl)
+    {}
+
+template<class>
+CONSTCD14
+inline
+year_month_day_last&
+year_month_day_last::operator+=(const months& m) NOEXCEPT
+{
+    *this = *this + m;
+    return *this;
 }
 
-template <class>
-CONSTCD14 inline year_month_day_last& year_month_day_last::operator+=(
-    const months& m) NOEXCEPT {
-  *this = *this + m;
-  return *this;
-}
-
-template <class>
-CONSTCD14 inline year_month_day_last& year_month_day_last::operator-=(
-    const months& m) NOEXCEPT {
-  *this = *this - m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_day_last&
+year_month_day_last::operator-=(const months& m) NOEXCEPT
+{
+    *this = *this - m;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_day_last& year_month_day_last::operator+=(
-    const years& y) NOEXCEPT {
-  *this = *this + y;
-  return *this;
+inline
+year_month_day_last&
+year_month_day_last::operator+=(const years& y) NOEXCEPT
+{
+    *this = *this + y;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_day_last& year_month_day_last::operator-=(
-    const years& y) NOEXCEPT {
-  *this = *this - y;
-  return *this;
+inline
+year_month_day_last&
+year_month_day_last::operator-=(const years& y) NOEXCEPT
+{
+    *this = *this - y;
+    return *this;
 }
 
-CONSTCD11 inline year year_month_day_last::year() const NOEXCEPT { return y_; }
-CONSTCD11 inline month year_month_day_last::month() const NOEXCEPT {
-  return mdl_.month();
-}
+CONSTCD11 inline year year_month_day_last::year() const NOEXCEPT {return y_;}
+CONSTCD11 inline month year_month_day_last::month() const NOEXCEPT {return mdl_.month();}
 
 CONSTCD11
-inline month_day_last year_month_day_last::month_day_last() const NOEXCEPT {
-  return mdl_;
+inline
+month_day_last
+year_month_day_last::month_day_last() const NOEXCEPT
+{
+    return mdl_;
 }
 
 CONSTCD14
-inline day year_month_day_last::day() const NOEXCEPT {
-  CONSTDATA date::day d[] = {date::day(31), date::day(28), date::day(31),
-                             date::day(30), date::day(31), date::day(30),
-                             date::day(31), date::day(31), date::day(30),
-                             date::day(31), date::day(30), date::day(31)};
-  return (month() != February || !y_.is_leap()) && mdl_.ok()
-             ? d[static_cast<unsigned>(month()) - 1]
-             : date::day{29};
+inline
+day
+year_month_day_last::day() const NOEXCEPT
+{
+    CONSTDATA date::day d[] =
+    {
+        date::day(31), date::day(28), date::day(31),
+        date::day(30), date::day(31), date::day(30),
+        date::day(31), date::day(31), date::day(30),
+        date::day(31), date::day(30), date::day(31)
+    };
+    return (month() != February || !y_.is_leap()) && mdl_.ok() ?
+        d[static_cast<unsigned>(month()) - 1] : date::day{29};
 }
 
 CONSTCD14
-inline year_month_day_last::operator sys_days() const NOEXCEPT {
-  return sys_days(year() / month() / day());
+inline
+year_month_day_last::operator sys_days() const NOEXCEPT
+{
+    return sys_days(year()/month()/day());
 }
 
 CONSTCD14
-inline year_month_day_last::operator local_days() const NOEXCEPT {
-  return local_days(year() / month() / day());
+inline
+year_month_day_last::operator local_days() const NOEXCEPT
+{
+    return local_days(year()/month()/day());
 }
 
 CONSTCD11
-inline bool year_month_day_last::ok() const NOEXCEPT {
-  return y_.ok() && mdl_.ok();
+inline
+bool
+year_month_day_last::ok() const NOEXCEPT
+{
+    return y_.ok() && mdl_.ok();
 }
 
 CONSTCD11
-inline bool operator==(const year_month_day_last& x,
-                       const year_month_day_last& y) NOEXCEPT {
-  return x.year() == y.year() && x.month_day_last() == y.month_day_last();
+inline
+bool
+operator==(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return x.year() == y.year() && x.month_day_last() == y.month_day_last();
 }
 
 CONSTCD11
-inline bool operator!=(const year_month_day_last& x,
-                       const year_month_day_last& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const year_month_day_last& x,
-                      const year_month_day_last& y) NOEXCEPT {
-  return x.year() < y.year()
-             ? true
-             : (x.year() > y.year()
-                    ? false
-                    : (x.month_day_last() < y.month_day_last()));
+inline
+bool
+operator<(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return x.year() < y.year() ? true
+        : (x.year() > y.year() ? false
+        : (x.month_day_last() < y.month_day_last()));
 }
 
 CONSTCD11
-inline bool operator>(const year_month_day_last& x,
-                      const year_month_day_last& y) NOEXCEPT {
-  return y < x;
+inline
+bool
+operator>(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator<=(const year_month_day_last& x,
-                       const year_month_day_last& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator<=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline bool operator>=(const year_month_day_last& x,
-                       const year_month_day_last& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator>=(const year_month_day_last& x, const year_month_day_last& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
-namespace detail {
+namespace detail
+{
 
-template <class CharT, class Traits>
-std::basic_ostream<CharT, Traits>& low_level_fmt(
-    std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl) {
-  low_level_fmt(os, ymdl.year()) << '/';
-  return low_level_fmt(os, ymdl.month_day_last());
+template<class CharT, class Traits>
+std::basic_ostream<CharT, Traits>&
+low_level_fmt(std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl)
+{
+    low_level_fmt(os, ymdl.year()) << '/';
+    return low_level_fmt(os, ymdl.month_day_last());
 }
 
 }  // namespace detail
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl) {
-  detail::low_level_fmt(os, ymdl);
-  if (!ymdl.ok()) os << " is not a valid year_month_day_last";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_day_last& ymdl)
+{
+    detail::low_level_fmt(os, ymdl);
+    if (!ymdl.ok())
+        os << " is not a valid year_month_day_last";
+    return os;
 }
 
-template <class>
-CONSTCD14 inline year_month_day_last operator+(const year_month_day_last& ymdl,
-                                               const months& dm) NOEXCEPT {
-  return (ymdl.year() / ymdl.month() + dm) / last;
+template<class>
+CONSTCD14
+inline
+year_month_day_last
+operator+(const year_month_day_last& ymdl, const months& dm) NOEXCEPT
+{
+    return (ymdl.year() / ymdl.month() + dm) / last;
 }
 
-template <class>
-CONSTCD14 inline year_month_day_last operator+(
-    const months& dm, const year_month_day_last& ymdl) NOEXCEPT {
-  return ymdl + dm;
+template<class>
+CONSTCD14
+inline
+year_month_day_last
+operator+(const months& dm, const year_month_day_last& ymdl) NOEXCEPT
+{
+    return ymdl + dm;
 }
 
-template <class>
-CONSTCD14 inline year_month_day_last operator-(const year_month_day_last& ymdl,
-                                               const months& dm) NOEXCEPT {
-  return ymdl + (-dm);
+template<class>
+CONSTCD14
+inline
+year_month_day_last
+operator-(const year_month_day_last& ymdl, const months& dm) NOEXCEPT
+{
+    return ymdl + (-dm);
 }
 
 CONSTCD11
-inline year_month_day_last operator+(const year_month_day_last& ymdl,
-                                     const years& dy) NOEXCEPT {
-  return {ymdl.year() + dy, ymdl.month_day_last()};
+inline
+year_month_day_last
+operator+(const year_month_day_last& ymdl, const years& dy) NOEXCEPT
+{
+    return {ymdl.year()+dy, ymdl.month_day_last()};
 }
 
 CONSTCD11
-inline year_month_day_last operator+(const years& dy,
-                                     const year_month_day_last& ymdl) NOEXCEPT {
-  return ymdl + dy;
+inline
+year_month_day_last
+operator+(const years& dy, const year_month_day_last& ymdl) NOEXCEPT
+{
+    return ymdl + dy;
 }
 
 CONSTCD11
-inline year_month_day_last operator-(const year_month_day_last& ymdl,
-                                     const years& dy) NOEXCEPT {
-  return ymdl + (-dy);
+inline
+year_month_day_last
+operator-(const year_month_day_last& ymdl, const years& dy) NOEXCEPT
+{
+    return ymdl + (-dy);
 }
 
 // year_month_day
 
 CONSTCD11
-inline year_month_day::year_month_day(const date::year& y, const date::month& m,
-                                      const date::day& d) NOEXCEPT : y_(y),
-                                                                     m_(m),
-                                                                     d_(d) {}
+inline
+year_month_day::year_month_day(const date::year& y, const date::month& m,
+                               const date::day& d) NOEXCEPT
+    : y_(y)
+    , m_(m)
+    , d_(d)
+    {}
 
 CONSTCD14
-inline year_month_day::year_month_day(const year_month_day_last& ymdl) NOEXCEPT
-    : y_(ymdl.year()),
-      m_(ymdl.month()),
-      d_(ymdl.day()) {}
+inline
+year_month_day::year_month_day(const year_month_day_last& ymdl) NOEXCEPT
+    : y_(ymdl.year())
+    , m_(ymdl.month())
+    , d_(ymdl.day())
+    {}
 
 CONSTCD14
-inline year_month_day::year_month_day(sys_days dp) NOEXCEPT
-    : year_month_day(from_days(dp.time_since_epoch())) {}
+inline
+year_month_day::year_month_day(sys_days dp) NOEXCEPT
+    : year_month_day(from_days(dp.time_since_epoch()))
+    {}
 
 CONSTCD14
-inline year_month_day::year_month_day(local_days dp) NOEXCEPT
-    : year_month_day(from_days(dp.time_since_epoch())) {}
+inline
+year_month_day::year_month_day(local_days dp) NOEXCEPT
+    : year_month_day(from_days(dp.time_since_epoch()))
+    {}
 
-CONSTCD11 inline year year_month_day::year() const NOEXCEPT { return y_; }
-CONSTCD11 inline month year_month_day::month() const NOEXCEPT { return m_; }
-CONSTCD11 inline day year_month_day::day() const NOEXCEPT { return d_; }
+CONSTCD11 inline year year_month_day::year() const NOEXCEPT {return y_;}
+CONSTCD11 inline month year_month_day::month() const NOEXCEPT {return m_;}
+CONSTCD11 inline day year_month_day::day() const NOEXCEPT {return d_;}
 
-template <class>
-CONSTCD14 inline year_month_day& year_month_day::operator+=(
-    const months& m) NOEXCEPT {
-  *this = *this + m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_day&
+year_month_day::operator+=(const months& m) NOEXCEPT
+{
+    *this = *this + m;
+    return *this;
 }
 
-template <class>
-CONSTCD14 inline year_month_day& year_month_day::operator-=(
-    const months& m) NOEXCEPT {
-  *this = *this - m;
-  return *this;
-}
-
+template<class>
 CONSTCD14
-inline year_month_day& year_month_day::operator+=(const years& y) NOEXCEPT {
-  *this = *this + y;
-  return *this;
-}
-
-CONSTCD14
-inline year_month_day& year_month_day::operator-=(const years& y) NOEXCEPT {
-  *this = *this - y;
-  return *this;
-}
-
-CONSTCD14
-inline days year_month_day::to_days() const NOEXCEPT {
-  static_assert(
-      std::numeric_limits<unsigned>::digits >= 18,
-      "This algorithm has not been ported to a 16 bit unsigned integer");
-  static_assert(
-      std::numeric_limits<int>::digits >= 20,
-      "This algorithm has not been ported to a 16 bit signed integer");
-  auto const y = static_cast<int>(y_) - (m_ <= February);
-  auto const m = static_cast<unsigned>(m_);
-  auto const d = static_cast<unsigned>(d_);
-  auto const era = (y >= 0 ? y : y - 399) / 400;
-  auto const yoe = static_cast<unsigned>(y - era * 400);             // [0, 399]
-  auto const doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;  // [0, 365]
-  auto const doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;  // [0, 146096]
-  return days{era * 146097 + static_cast<int>(doe) - 719468};
+inline
+year_month_day&
+year_month_day::operator-=(const months& m) NOEXCEPT
+{
+    *this = *this - m;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_day::operator sys_days() const NOEXCEPT {
-  return sys_days{to_days()};
+inline
+year_month_day&
+year_month_day::operator+=(const years& y) NOEXCEPT
+{
+    *this = *this + y;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_day::operator local_days() const NOEXCEPT {
-  return local_days{to_days()};
+inline
+year_month_day&
+year_month_day::operator-=(const years& y) NOEXCEPT
+{
+    *this = *this - y;
+    return *this;
 }
 
 CONSTCD14
-inline bool year_month_day::ok() const NOEXCEPT {
-  if (!(y_.ok() && m_.ok())) return false;
-  return date::day{1} <= d_ && d_ <= (y_ / m_ / last).day();
+inline
+days
+year_month_day::to_days() const NOEXCEPT
+{
+    static_assert(std::numeric_limits<unsigned>::digits >= 18,
+             "This algorithm has not been ported to a 16 bit unsigned integer");
+    static_assert(std::numeric_limits<int>::digits >= 20,
+             "This algorithm has not been ported to a 16 bit signed integer");
+    auto const y = static_cast<int>(y_) - (m_ <= February);
+    auto const m = static_cast<unsigned>(m_);
+    auto const d = static_cast<unsigned>(d_);
+    auto const era = (y >= 0 ? y : y-399) / 400;
+    auto const yoe = static_cast<unsigned>(y - era * 400);       // [0, 399]
+    auto const doy = (153*(m > 2 ? m-3 : m+9) + 2)/5 + d-1;      // [0, 365]
+    auto const doe = yoe * 365 + yoe/4 - yoe/100 + doy;          // [0, 146096]
+    return days{era * 146097 + static_cast<int>(doe) - 719468};
+}
+
+CONSTCD14
+inline
+year_month_day::operator sys_days() const NOEXCEPT
+{
+    return sys_days{to_days()};
+}
+
+CONSTCD14
+inline
+year_month_day::operator local_days() const NOEXCEPT
+{
+    return local_days{to_days()};
+}
+
+CONSTCD14
+inline
+bool
+year_month_day::ok() const NOEXCEPT
+{
+    if (!(y_.ok() && m_.ok()))
+        return false;
+    return date::day{1} <= d_ && d_ <= (y_ / m_ / last).day();
 }
 
 CONSTCD11
-inline bool operator==(const year_month_day& x,
-                       const year_month_day& y) NOEXCEPT {
-  return x.year() == y.year() && x.month() == y.month() && x.day() == y.day();
+inline
+bool
+operator==(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return x.year() == y.year() && x.month() == y.month() && x.day() == y.day();
 }
 
 CONSTCD11
-inline bool operator!=(const year_month_day& x,
-                       const year_month_day& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
 CONSTCD11
-inline bool operator<(const year_month_day& x,
-                      const year_month_day& y) NOEXCEPT {
-  return x.year() < y.year()
-             ? true
-             : (x.year() > y.year()
-                    ? false
-                    : (x.month() < y.month()
-                           ? true
-                           : (x.month() > y.month() ? false
-                                                    : (x.day() < y.day()))));
+inline
+bool
+operator<(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return x.year() < y.year() ? true
+        : (x.year() > y.year() ? false
+        : (x.month() < y.month() ? true
+        : (x.month() > y.month() ? false
+        : (x.day() < y.day()))));
 }
 
 CONSTCD11
-inline bool operator>(const year_month_day& x,
-                      const year_month_day& y) NOEXCEPT {
-  return y < x;
+inline
+bool
+operator>(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return y < x;
 }
 
 CONSTCD11
-inline bool operator<=(const year_month_day& x,
-                       const year_month_day& y) NOEXCEPT {
-  return !(y < x);
+inline
+bool
+operator<=(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return !(y < x);
 }
 
 CONSTCD11
-inline bool operator>=(const year_month_day& x,
-                       const year_month_day& y) NOEXCEPT {
-  return !(x < y);
+inline
+bool
+operator>=(const year_month_day& x, const year_month_day& y) NOEXCEPT
+{
+    return !(x < y);
 }
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_day& ymd) {
-  detail::save_ostream<CharT, Traits> _(os);
-  os.fill('0');
-  os.flags(std::ios::dec | std::ios::right);
-  os.imbue(std::locale::classic());
-  os << static_cast<int>(ymd.year()) << '-';
-  os.width(2);
-  os << static_cast<unsigned>(ymd.month()) << '-';
-  os.width(2);
-  os << static_cast<unsigned>(ymd.day());
-  if (!ymd.ok()) os << " is not a valid year_month_day";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_day& ymd)
+{
+    detail::save_ostream<CharT, Traits> _(os);
+    os.fill('0');
+    os.flags(std::ios::dec | std::ios::right);
+    os.imbue(std::locale::classic());
+    os << static_cast<int>(ymd.year()) << '-';
+    os.width(2);
+    os << static_cast<unsigned>(ymd.month()) << '-';
+    os.width(2);
+    os << static_cast<unsigned>(ymd.day());
+    if (!ymd.ok())
+        os << " is not a valid year_month_day";
+    return os;
 }
 
 CONSTCD14
-inline year_month_day year_month_day::from_days(days dp) NOEXCEPT {
-  static_assert(
-      std::numeric_limits<unsigned>::digits >= 18,
-      "This algorithm has not been ported to a 16 bit unsigned integer");
-  static_assert(
-      std::numeric_limits<int>::digits >= 20,
-      "This algorithm has not been ported to a 16 bit signed integer");
-  auto const z = dp.count() + 719468;
-  auto const era = (z >= 0 ? z : z - 146096) / 146097;
-  auto const doe = static_cast<unsigned>(z - era * 146097);  // [0, 146096]
-  auto const yoe =
-      (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;  // [0, 399]
-  auto const y = static_cast<days::rep>(yoe) + era * 400;
-  auto const doy = doe - (365 * yoe + yoe / 4 - yoe / 100);  // [0, 365]
-  auto const mp = (5 * doy + 2) / 153;                       // [0, 11]
-  auto const d = doy - (153 * mp + 2) / 5 + 1;               // [1, 31]
-  auto const m = mp < 10 ? mp + 3 : mp - 9;                  // [1, 12]
-  return year_month_day{date::year{y + (m <= 2)}, date::month(m), date::day(d)};
+inline
+year_month_day
+year_month_day::from_days(days dp) NOEXCEPT
+{
+    static_assert(std::numeric_limits<unsigned>::digits >= 18,
+             "This algorithm has not been ported to a 16 bit unsigned integer");
+    static_assert(std::numeric_limits<int>::digits >= 20,
+             "This algorithm has not been ported to a 16 bit signed integer");
+    auto const z = dp.count() + 719468;
+    auto const era = (z >= 0 ? z : z - 146096) / 146097;
+    auto const doe = static_cast<unsigned>(z - era * 146097);          // [0, 146096]
+    auto const yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;  // [0, 399]
+    auto const y = static_cast<days::rep>(yoe) + era * 400;
+    auto const doy = doe - (365*yoe + yoe/4 - yoe/100);                // [0, 365]
+    auto const mp = (5*doy + 2)/153;                                   // [0, 11]
+    auto const d = doy - (153*mp+2)/5 + 1;                             // [1, 31]
+    auto const m = mp < 10 ? mp+3 : mp-9;                              // [1, 12]
+    return year_month_day{date::year{y + (m <= 2)}, date::month(m), date::day(d)};
 }
 
-template <class>
-CONSTCD14 inline year_month_day operator+(const year_month_day& ymd,
-                                          const months& dm) NOEXCEPT {
-  return (ymd.year() / ymd.month() + dm) / ymd.day();
+template<class>
+CONSTCD14
+inline
+year_month_day
+operator+(const year_month_day& ymd, const months& dm) NOEXCEPT
+{
+    return (ymd.year() / ymd.month() + dm) / ymd.day();
 }
 
-template <class>
-CONSTCD14 inline year_month_day operator+(const months& dm,
-                                          const year_month_day& ymd) NOEXCEPT {
-  return ymd + dm;
+template<class>
+CONSTCD14
+inline
+year_month_day
+operator+(const months& dm, const year_month_day& ymd) NOEXCEPT
+{
+    return ymd + dm;
 }
 
-template <class>
-CONSTCD14 inline year_month_day operator-(const year_month_day& ymd,
-                                          const months& dm) NOEXCEPT {
-  return ymd + (-dm);
-}
-
-CONSTCD11
-inline year_month_day operator+(const year_month_day& ymd,
-                                const years& dy) NOEXCEPT {
-  return (ymd.year() + dy) / ymd.month() / ymd.day();
-}
-
-CONSTCD11
-inline year_month_day operator+(const years& dy,
-                                const year_month_day& ymd) NOEXCEPT {
-  return ymd + dy;
+template<class>
+CONSTCD14
+inline
+year_month_day
+operator-(const year_month_day& ymd, const months& dm) NOEXCEPT
+{
+    return ymd + (-dm);
 }
 
 CONSTCD11
-inline year_month_day operator-(const year_month_day& ymd,
-                                const years& dy) NOEXCEPT {
-  return ymd + (-dy);
+inline
+year_month_day
+operator+(const year_month_day& ymd, const years& dy) NOEXCEPT
+{
+    return (ymd.year() + dy) / ymd.month() / ymd.day();
+}
+
+CONSTCD11
+inline
+year_month_day
+operator+(const years& dy, const year_month_day& ymd) NOEXCEPT
+{
+    return ymd + dy;
+}
+
+CONSTCD11
+inline
+year_month_day
+operator-(const year_month_day& ymd, const years& dy) NOEXCEPT
+{
+    return ymd + (-dy);
 }
 
 // year_month_weekday
 
 CONSTCD11
-inline year_month_weekday::year_month_weekday(
-    const date::year& y, const date::month& m,
-    const date::weekday_indexed& wdi) NOEXCEPT : y_(y),
-                                                 m_(m),
-                                                 wdi_(wdi) {}
+inline
+year_month_weekday::year_month_weekday(const date::year& y, const date::month& m,
+                                       const date::weekday_indexed& wdi)
+        NOEXCEPT
+    : y_(y)
+    , m_(m)
+    , wdi_(wdi)
+    {}
 
 CONSTCD14
-inline year_month_weekday::year_month_weekday(const sys_days& dp) NOEXCEPT
-    : year_month_weekday(from_days(dp.time_since_epoch())) {}
+inline
+year_month_weekday::year_month_weekday(const sys_days& dp) NOEXCEPT
+    : year_month_weekday(from_days(dp.time_since_epoch()))
+    {}
 
 CONSTCD14
-inline year_month_weekday::year_month_weekday(const local_days& dp) NOEXCEPT
-    : year_month_weekday(from_days(dp.time_since_epoch())) {}
+inline
+year_month_weekday::year_month_weekday(const local_days& dp) NOEXCEPT
+    : year_month_weekday(from_days(dp.time_since_epoch()))
+    {}
 
-template <class>
-CONSTCD14 inline year_month_weekday& year_month_weekday::operator+=(
-    const months& m) NOEXCEPT {
-  *this = *this + m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_weekday&
+year_month_weekday::operator+=(const months& m) NOEXCEPT
+{
+    *this = *this + m;
+    return *this;
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday& year_month_weekday::operator-=(
-    const months& m) NOEXCEPT {
-  *this = *this - m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_weekday&
+year_month_weekday::operator-=(const months& m) NOEXCEPT
+{
+    *this = *this - m;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_weekday& year_month_weekday::operator+=(
-    const years& y) NOEXCEPT {
-  *this = *this + y;
-  return *this;
+inline
+year_month_weekday&
+year_month_weekday::operator+=(const years& y) NOEXCEPT
+{
+    *this = *this + y;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_weekday& year_month_weekday::operator-=(
-    const years& y) NOEXCEPT {
-  *this = *this - y;
-  return *this;
+inline
+year_month_weekday&
+year_month_weekday::operator-=(const years& y) NOEXCEPT
+{
+    *this = *this - y;
+    return *this;
 }
 
-CONSTCD11 inline year year_month_weekday::year() const NOEXCEPT { return y_; }
-CONSTCD11 inline month year_month_weekday::month() const NOEXCEPT { return m_; }
+CONSTCD11 inline year year_month_weekday::year() const NOEXCEPT {return y_;}
+CONSTCD11 inline month year_month_weekday::month() const NOEXCEPT {return m_;}
 
 CONSTCD11
-inline weekday year_month_weekday::weekday() const NOEXCEPT {
-  return wdi_.weekday();
-}
-
-CONSTCD11
-inline unsigned year_month_weekday::index() const NOEXCEPT {
-  return wdi_.index();
-}
-
-CONSTCD11
-inline weekday_indexed year_month_weekday::weekday_indexed() const NOEXCEPT {
-  return wdi_;
-}
-
-CONSTCD14
-inline year_month_weekday::operator sys_days() const NOEXCEPT {
-  return sys_days{to_days()};
-}
-
-CONSTCD14
-inline year_month_weekday::operator local_days() const NOEXCEPT {
-  return local_days{to_days()};
-}
-
-CONSTCD14
-inline bool year_month_weekday::ok() const NOEXCEPT {
-  if (!y_.ok() || !m_.ok() || !wdi_.weekday().ok() || wdi_.index() < 1)
-    return false;
-  if (wdi_.index() <= 4) return true;
-  auto d2 = wdi_.weekday() - date::weekday(static_cast<sys_days>(y_ / m_ / 1)) +
-            days((wdi_.index() - 1) * 7 + 1);
-  return static_cast<unsigned>(d2.count()) <=
-         static_cast<unsigned>((y_ / m_ / last).day());
-}
-
-CONSTCD14
-inline year_month_weekday year_month_weekday::from_days(days d) NOEXCEPT {
-  sys_days dp{d};
-  auto const wd = date::weekday(dp);
-  auto const ymd = year_month_day(dp);
-  return {ymd.year(), ymd.month(),
-          wd[(static_cast<unsigned>(ymd.day()) - 1) / 7 + 1]};
-}
-
-CONSTCD14
-inline days year_month_weekday::to_days() const NOEXCEPT {
-  auto d = sys_days(y_ / m_ / 1);
-  return (d +
-          (wdi_.weekday() - date::weekday(d) + days{(wdi_.index() - 1) * 7}))
-      .time_since_epoch();
+inline
+weekday
+year_month_weekday::weekday() const NOEXCEPT
+{
+    return wdi_.weekday();
 }
 
 CONSTCD11
-inline bool operator==(const year_month_weekday& x,
-                       const year_month_weekday& y) NOEXCEPT {
-  return x.year() == y.year() && x.month() == y.month() &&
-         x.weekday_indexed() == y.weekday_indexed();
+inline
+unsigned
+year_month_weekday::index() const NOEXCEPT
+{
+    return wdi_.index();
 }
 
 CONSTCD11
-inline bool operator!=(const year_month_weekday& x,
-                       const year_month_weekday& y) NOEXCEPT {
-  return !(x == y);
+inline
+weekday_indexed
+year_month_weekday::weekday_indexed() const NOEXCEPT
+{
+    return wdi_;
 }
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const year_month_weekday& ymwdi) {
-  detail::low_level_fmt(os, ymwdi.year()) << '/';
-  detail::low_level_fmt(os, ymwdi.month()) << '/';
-  detail::low_level_fmt(os, ymwdi.weekday_indexed());
-  if (!ymwdi.ok()) os << " is not a valid year_month_weekday";
-  return os;
+CONSTCD14
+inline
+year_month_weekday::operator sys_days() const NOEXCEPT
+{
+    return sys_days{to_days()};
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday operator+(const year_month_weekday& ymwd,
-                                              const months& dm) NOEXCEPT {
-  return (ymwd.year() / ymwd.month() + dm) / ymwd.weekday_indexed();
+CONSTCD14
+inline
+year_month_weekday::operator local_days() const NOEXCEPT
+{
+    return local_days{to_days()};
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday operator+(
-    const months& dm, const year_month_weekday& ymwd) NOEXCEPT {
-  return ymwd + dm;
+CONSTCD14
+inline
+bool
+year_month_weekday::ok() const NOEXCEPT
+{
+    if (!y_.ok() || !m_.ok() || !wdi_.weekday().ok() || wdi_.index() < 1)
+        return false;
+    if (wdi_.index() <= 4)
+        return true;
+    auto d2 = wdi_.weekday() - date::weekday(static_cast<sys_days>(y_/m_/1)) +
+                  days((wdi_.index()-1)*7 + 1);
+    return static_cast<unsigned>(d2.count()) <= static_cast<unsigned>((y_/m_/last).day());
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday operator-(const year_month_weekday& ymwd,
-                                              const months& dm) NOEXCEPT {
-  return ymwd + (-dm);
+CONSTCD14
+inline
+year_month_weekday
+year_month_weekday::from_days(days d) NOEXCEPT
+{
+    sys_days dp{d};
+    auto const wd = date::weekday(dp);
+    auto const ymd = year_month_day(dp);
+    return {ymd.year(), ymd.month(), wd[(static_cast<unsigned>(ymd.day())-1)/7+1]};
+}
+
+CONSTCD14
+inline
+days
+year_month_weekday::to_days() const NOEXCEPT
+{
+    auto d = sys_days(y_/m_/1);
+    return (d + (wdi_.weekday() - date::weekday(d) + days{(wdi_.index()-1)*7})
+           ).time_since_epoch();
 }
 
 CONSTCD11
-inline year_month_weekday operator+(const year_month_weekday& ymwd,
-                                    const years& dy) NOEXCEPT {
-  return {ymwd.year() + dy, ymwd.month(), ymwd.weekday_indexed()};
+inline
+bool
+operator==(const year_month_weekday& x, const year_month_weekday& y) NOEXCEPT
+{
+    return x.year() == y.year() && x.month() == y.month() &&
+           x.weekday_indexed() == y.weekday_indexed();
 }
 
 CONSTCD11
-inline year_month_weekday operator+(const years& dy,
-                                    const year_month_weekday& ymwd) NOEXCEPT {
-  return ymwd + dy;
+inline
+bool
+operator!=(const year_month_weekday& x, const year_month_weekday& y) NOEXCEPT
+{
+    return !(x == y);
+}
+
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday& ymwdi)
+{
+    detail::low_level_fmt(os, ymwdi.year()) << '/';
+    detail::low_level_fmt(os, ymwdi.month()) << '/';
+    detail::low_level_fmt(os, ymwdi.weekday_indexed());
+    if (!ymwdi.ok())
+        os << " is not a valid year_month_weekday";
+    return os;
+}
+
+template<class>
+CONSTCD14
+inline
+year_month_weekday
+operator+(const year_month_weekday& ymwd, const months& dm) NOEXCEPT
+{
+    return (ymwd.year() / ymwd.month() + dm) / ymwd.weekday_indexed();
+}
+
+template<class>
+CONSTCD14
+inline
+year_month_weekday
+operator+(const months& dm, const year_month_weekday& ymwd) NOEXCEPT
+{
+    return ymwd + dm;
+}
+
+template<class>
+CONSTCD14
+inline
+year_month_weekday
+operator-(const year_month_weekday& ymwd, const months& dm) NOEXCEPT
+{
+    return ymwd + (-dm);
 }
 
 CONSTCD11
-inline year_month_weekday operator-(const year_month_weekday& ymwd,
-                                    const years& dy) NOEXCEPT {
-  return ymwd + (-dy);
+inline
+year_month_weekday
+operator+(const year_month_weekday& ymwd, const years& dy) NOEXCEPT
+{
+    return {ymwd.year()+dy, ymwd.month(), ymwd.weekday_indexed()};
+}
+
+CONSTCD11
+inline
+year_month_weekday
+operator+(const years& dy, const year_month_weekday& ymwd) NOEXCEPT
+{
+    return ymwd + dy;
+}
+
+CONSTCD11
+inline
+year_month_weekday
+operator-(const year_month_weekday& ymwd, const years& dy) NOEXCEPT
+{
+    return ymwd + (-dy);
 }
 
 // year_month_weekday_last
 
 CONSTCD11
-inline year_month_weekday_last::year_month_weekday_last(
-    const date::year& y, const date::month& m,
-    const date::weekday_last& wdl) NOEXCEPT : y_(y),
-                                              m_(m),
-                                              wdl_(wdl) {}
+inline
+year_month_weekday_last::year_month_weekday_last(const date::year& y,
+                                                 const date::month& m,
+                                                 const date::weekday_last& wdl) NOEXCEPT
+    : y_(y)
+    , m_(m)
+    , wdl_(wdl)
+    {}
 
-template <class>
-CONSTCD14 inline year_month_weekday_last& year_month_weekday_last::operator+=(
-    const months& m) NOEXCEPT {
-  *this = *this + m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_weekday_last&
+year_month_weekday_last::operator+=(const months& m) NOEXCEPT
+{
+    *this = *this + m;
+    return *this;
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday_last& year_month_weekday_last::operator-=(
-    const months& m) NOEXCEPT {
-  *this = *this - m;
-  return *this;
+template<class>
+CONSTCD14
+inline
+year_month_weekday_last&
+year_month_weekday_last::operator-=(const months& m) NOEXCEPT
+{
+    *this = *this - m;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_weekday_last& year_month_weekday_last::operator+=(
-    const years& y) NOEXCEPT {
-  *this = *this + y;
-  return *this;
+inline
+year_month_weekday_last&
+year_month_weekday_last::operator+=(const years& y) NOEXCEPT
+{
+    *this = *this + y;
+    return *this;
 }
 
 CONSTCD14
-inline year_month_weekday_last& year_month_weekday_last::operator-=(
-    const years& y) NOEXCEPT {
-  *this = *this - y;
-  return *this;
+inline
+year_month_weekday_last&
+year_month_weekday_last::operator-=(const years& y) NOEXCEPT
+{
+    *this = *this - y;
+    return *this;
 }
 
-CONSTCD11 inline year year_month_weekday_last::year() const NOEXCEPT {
-  return y_;
-}
-CONSTCD11 inline month year_month_weekday_last::month() const NOEXCEPT {
-  return m_;
+CONSTCD11 inline year year_month_weekday_last::year() const NOEXCEPT {return y_;}
+CONSTCD11 inline month year_month_weekday_last::month() const NOEXCEPT {return m_;}
+
+CONSTCD11
+inline
+weekday
+year_month_weekday_last::weekday() const NOEXCEPT
+{
+    return wdl_.weekday();
 }
 
 CONSTCD11
-inline weekday year_month_weekday_last::weekday() const NOEXCEPT {
-  return wdl_.weekday();
-}
-
-CONSTCD11
-inline weekday_last year_month_weekday_last::weekday_last() const NOEXCEPT {
-  return wdl_;
+inline
+weekday_last
+year_month_weekday_last::weekday_last() const NOEXCEPT
+{
+    return wdl_;
 }
 
 CONSTCD14
-inline year_month_weekday_last::operator sys_days() const NOEXCEPT {
-  return sys_days{to_days()};
+inline
+year_month_weekday_last::operator sys_days() const NOEXCEPT
+{
+    return sys_days{to_days()};
 }
 
 CONSTCD14
-inline year_month_weekday_last::operator local_days() const NOEXCEPT {
-  return local_days{to_days()};
+inline
+year_month_weekday_last::operator local_days() const NOEXCEPT
+{
+    return local_days{to_days()};
 }
 
 CONSTCD11
-inline bool year_month_weekday_last::ok() const NOEXCEPT {
-  return y_.ok() && m_.ok() && wdl_.ok();
+inline
+bool
+year_month_weekday_last::ok() const NOEXCEPT
+{
+    return y_.ok() && m_.ok() && wdl_.ok();
 }
 
 CONSTCD14
-inline days year_month_weekday_last::to_days() const NOEXCEPT {
-  auto const d = sys_days(y_ / m_ / last);
-  return (d - (date::weekday{d} - wdl_.weekday())).time_since_epoch();
+inline
+days
+year_month_weekday_last::to_days() const NOEXCEPT
+{
+    auto const d = sys_days(y_/m_/last);
+    return (d - (date::weekday{d} - wdl_.weekday())).time_since_epoch();
 }
 
 CONSTCD11
-inline bool operator==(const year_month_weekday_last& x,
-                       const year_month_weekday_last& y) NOEXCEPT {
-  return x.year() == y.year() && x.month() == y.month() &&
-         x.weekday_last() == y.weekday_last();
+inline
+bool
+operator==(const year_month_weekday_last& x, const year_month_weekday_last& y) NOEXCEPT
+{
+    return x.year() == y.year() && x.month() == y.month() &&
+           x.weekday_last() == y.weekday_last();
 }
 
 CONSTCD11
-inline bool operator!=(const year_month_weekday_last& x,
-                       const year_month_weekday_last& y) NOEXCEPT {
-  return !(x == y);
+inline
+bool
+operator!=(const year_month_weekday_last& x, const year_month_weekday_last& y) NOEXCEPT
+{
+    return !(x == y);
 }
 
-template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os,
-    const year_month_weekday_last& ymwdl) {
-  detail::low_level_fmt(os, ymwdl.year()) << '/';
-  detail::low_level_fmt(os, ymwdl.month()) << '/';
-  detail::low_level_fmt(os, ymwdl.weekday_last());
-  if (!ymwdl.ok()) os << " is not a valid year_month_weekday_last";
-  return os;
+template<class CharT, class Traits>
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last& ymwdl)
+{
+    detail::low_level_fmt(os, ymwdl.year()) << '/';
+    detail::low_level_fmt(os, ymwdl.month()) << '/';
+    detail::low_level_fmt(os, ymwdl.weekday_last());
+    if (!ymwdl.ok())
+        os << " is not a valid year_month_weekday_last";
+    return os;
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday_last operator+(
-    const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT {
-  return (ymwdl.year() / ymwdl.month() + dm) / ymwdl.weekday_last();
+template<class>
+CONSTCD14
+inline
+year_month_weekday_last
+operator+(const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT
+{
+    return (ymwdl.year() / ymwdl.month() + dm) / ymwdl.weekday_last();
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday_last operator+(
-    const months& dm, const year_month_weekday_last& ymwdl) NOEXCEPT {
-  return ymwdl + dm;
+template<class>
+CONSTCD14
+inline
+year_month_weekday_last
+operator+(const months& dm, const year_month_weekday_last& ymwdl) NOEXCEPT
+{
+    return ymwdl + dm;
 }
 
-template <class>
-CONSTCD14 inline year_month_weekday_last operator-(
-    const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT {
-  return ymwdl + (-dm);
+template<class>
+CONSTCD14
+inline
+year_month_weekday_last
+operator-(const year_month_weekday_last& ymwdl, const months& dm) NOEXCEPT
+{
+    return ymwdl + (-dm);
 }
 
 CONSTCD11
-inline year_month_weekday_last operator+(const year_month_weekday_last& ymwdl,
-                                         const years& dy) NOEXCEPT {
-  return {ymwdl.year() + dy, ymwdl.month(), ymwdl.weekday_last()};
+inline
+year_month_weekday_last
+operator+(const year_month_weekday_last& ymwdl, const years& dy) NOEXCEPT
+{
+    return {ymwdl.year()+dy, ymwdl.month(), ymwdl.weekday_last()};
 }
 
 CONSTCD11
-inline year_month_weekday_last operator+(
-    const years& dy, const year_month_weekday_last& ymwdl) NOEXCEPT {
-  return ymwdl + dy;
+inline
+year_month_weekday_last
+operator+(const years& dy, const year_month_weekday_last& ymwdl) NOEXCEPT
+{
+    return ymwdl + dy;
 }
 
 CONSTCD11
-inline year_month_weekday_last operator-(const year_month_weekday_last& ymwdl,
-                                         const years& dy) NOEXCEPT {
-  return ymwdl + (-dy);
+inline
+year_month_weekday_last
+operator-(const year_month_weekday_last& ymwdl, const years& dy) NOEXCEPT
+{
+    return ymwdl + (-dy);
 }
 
 // year_month from operator/()
 
 CONSTCD11
-inline year_month operator/(const year& y, const month& m) NOEXCEPT {
-  return {y, m};
+inline
+year_month
+operator/(const year& y, const month& m) NOEXCEPT
+{
+    return {y, m};
 }
 
 CONSTCD11
-inline year_month operator/(const year& y, int m) NOEXCEPT {
-  return y / month(static_cast<unsigned>(m));
+inline
+year_month
+operator/(const year& y, int   m) NOEXCEPT
+{
+    return y / month(static_cast<unsigned>(m));
 }
 
 // month_day from operator/()
 
 CONSTCD11
-inline month_day operator/(const month& m, const day& d) NOEXCEPT {
-  return {m, d};
+inline
+month_day
+operator/(const month& m, const day& d) NOEXCEPT
+{
+    return {m, d};
 }
 
 CONSTCD11
-inline month_day operator/(const day& d, const month& m) NOEXCEPT {
-  return m / d;
+inline
+month_day
+operator/(const day& d, const month& m) NOEXCEPT
+{
+    return m / d;
 }
 
 CONSTCD11
-inline month_day operator/(const month& m, int d) NOEXCEPT {
-  return m / day(static_cast<unsigned>(d));
+inline
+month_day
+operator/(const month& m, int d) NOEXCEPT
+{
+    return m / day(static_cast<unsigned>(d));
 }
 
 CONSTCD11
-inline month_day operator/(int m, const day& d) NOEXCEPT {
-  return month(static_cast<unsigned>(m)) / d;
+inline
+month_day
+operator/(int m, const day& d) NOEXCEPT
+{
+    return month(static_cast<unsigned>(m)) / d;
 }
 
-CONSTCD11 inline month_day operator/(const day& d, int m) NOEXCEPT {
-  return m / d;
-}
+CONSTCD11 inline month_day operator/(const day& d, int m) NOEXCEPT {return m / d;}
 
 // month_day_last from operator/()
 
 CONSTCD11
-inline month_day_last operator/(const month& m, last_spec) NOEXCEPT {
-  return month_day_last{m};
+inline
+month_day_last
+operator/(const month& m, last_spec) NOEXCEPT
+{
+    return month_day_last{m};
 }
 
 CONSTCD11
-inline month_day_last operator/(last_spec, const month& m) NOEXCEPT {
-  return m / last;
+inline
+month_day_last
+operator/(last_spec, const month& m) NOEXCEPT
+{
+    return m/last;
 }
 
 CONSTCD11
-inline month_day_last operator/(int m, last_spec) NOEXCEPT {
-  return month(static_cast<unsigned>(m)) / last;
+inline
+month_day_last
+operator/(int m, last_spec) NOEXCEPT
+{
+    return month(static_cast<unsigned>(m))/last;
 }
 
 CONSTCD11
-inline month_day_last operator/(last_spec, int m) NOEXCEPT { return m / last; }
+inline
+month_day_last
+operator/(last_spec, int m) NOEXCEPT
+{
+    return m/last;
+}
 
 // month_weekday from operator/()
 
 CONSTCD11
-inline month_weekday operator/(const month& m,
-                               const weekday_indexed& wdi) NOEXCEPT {
-  return {m, wdi};
+inline
+month_weekday
+operator/(const month& m, const weekday_indexed& wdi) NOEXCEPT
+{
+    return {m, wdi};
 }
 
 CONSTCD11
-inline month_weekday operator/(const weekday_indexed& wdi,
-                               const month& m) NOEXCEPT {
-  return m / wdi;
+inline
+month_weekday
+operator/(const weekday_indexed& wdi, const month& m) NOEXCEPT
+{
+    return m / wdi;
 }
 
 CONSTCD11
-inline month_weekday operator/(int m, const weekday_indexed& wdi) NOEXCEPT {
-  return month(static_cast<unsigned>(m)) / wdi;
+inline
+month_weekday
+operator/(int m, const weekday_indexed& wdi) NOEXCEPT
+{
+    return month(static_cast<unsigned>(m)) / wdi;
 }
 
 CONSTCD11
-inline month_weekday operator/(const weekday_indexed& wdi, int m) NOEXCEPT {
-  return m / wdi;
+inline
+month_weekday
+operator/(const weekday_indexed& wdi, int m) NOEXCEPT
+{
+    return m / wdi;
 }
 
 // month_weekday_last from operator/()
 
 CONSTCD11
-inline month_weekday_last operator/(const month& m,
-                                    const weekday_last& wdl) NOEXCEPT {
-  return {m, wdl};
+inline
+month_weekday_last
+operator/(const month& m, const weekday_last& wdl) NOEXCEPT
+{
+    return {m, wdl};
 }
 
 CONSTCD11
-inline month_weekday_last operator/(const weekday_last& wdl,
-                                    const month& m) NOEXCEPT {
-  return m / wdl;
+inline
+month_weekday_last
+operator/(const weekday_last& wdl, const month& m) NOEXCEPT
+{
+    return m / wdl;
 }
 
 CONSTCD11
-inline month_weekday_last operator/(int m, const weekday_last& wdl) NOEXCEPT {
-  return month(static_cast<unsigned>(m)) / wdl;
+inline
+month_weekday_last
+operator/(int m, const weekday_last& wdl) NOEXCEPT
+{
+    return month(static_cast<unsigned>(m)) / wdl;
 }
 
 CONSTCD11
-inline month_weekday_last operator/(const weekday_last& wdl, int m) NOEXCEPT {
-  return m / wdl;
+inline
+month_weekday_last
+operator/(const weekday_last& wdl, int m) NOEXCEPT
+{
+    return m / wdl;
 }
 
 // year_month_day from operator/()
 
 CONSTCD11
-inline year_month_day operator/(const year_month& ym, const day& d) NOEXCEPT {
-  return {ym.year(), ym.month(), d};
+inline
+year_month_day
+operator/(const year_month& ym, const day& d) NOEXCEPT
+{
+    return {ym.year(), ym.month(), d};
 }
 
 CONSTCD11
-inline year_month_day operator/(const year_month& ym, int d) NOEXCEPT {
-  return ym / day(static_cast<unsigned>(d));
+inline
+year_month_day
+operator/(const year_month& ym, int d)  NOEXCEPT
+{
+    return ym / day(static_cast<unsigned>(d));
 }
 
 CONSTCD11
-inline year_month_day operator/(const year& y, const month_day& md) NOEXCEPT {
-  return y / md.month() / md.day();
+inline
+year_month_day
+operator/(const year& y, const month_day& md) NOEXCEPT
+{
+    return y / md.month() / md.day();
 }
 
 CONSTCD11
-inline year_month_day operator/(int y, const month_day& md) NOEXCEPT {
-  return year(y) / md;
+inline
+year_month_day
+operator/(int y, const month_day& md) NOEXCEPT
+{
+    return year(y) / md;
 }
 
 CONSTCD11
-inline year_month_day operator/(const month_day& md, const year& y) NOEXCEPT {
-  return y / md;
+inline
+year_month_day
+operator/(const month_day& md, const year& y)  NOEXCEPT
+{
+    return y / md;
 }
 
 CONSTCD11
-inline year_month_day operator/(const month_day& md, int y) NOEXCEPT {
-  return year(y) / md;
+inline
+year_month_day
+operator/(const month_day& md, int y) NOEXCEPT
+{
+    return year(y) / md;
 }
 
 // year_month_day_last from operator/()
 
 CONSTCD11
-inline year_month_day_last operator/(const year_month& ym, last_spec) NOEXCEPT {
-  return {ym.year(), month_day_last{ym.month()}};
+inline
+year_month_day_last
+operator/(const year_month& ym, last_spec) NOEXCEPT
+{
+    return {ym.year(), month_day_last{ym.month()}};
 }
 
 CONSTCD11
-inline year_month_day_last operator/(const year& y,
-                                     const month_day_last& mdl) NOEXCEPT {
-  return {y, mdl};
+inline
+year_month_day_last
+operator/(const year& y, const month_day_last& mdl) NOEXCEPT
+{
+    return {y, mdl};
 }
 
 CONSTCD11
-inline year_month_day_last operator/(int y,
-                                     const month_day_last& mdl) NOEXCEPT {
-  return year(y) / mdl;
+inline
+year_month_day_last
+operator/(int y, const month_day_last& mdl) NOEXCEPT
+{
+    return year(y) / mdl;
 }
 
 CONSTCD11
-inline year_month_day_last operator/(const month_day_last& mdl,
-                                     const year& y) NOEXCEPT {
-  return y / mdl;
+inline
+year_month_day_last
+operator/(const month_day_last& mdl, const year& y) NOEXCEPT
+{
+    return y / mdl;
 }
 
 CONSTCD11
-inline year_month_day_last operator/(const month_day_last& mdl,
-                                     int y) NOEXCEPT {
-  return year(y) / mdl;
+inline
+year_month_day_last
+operator/(const month_day_last& mdl, int y) NOEXCEPT
+{
+    return year(y) / mdl;
 }
 
 // year_month_weekday from operator/()
 
 CONSTCD11
-inline year_month_weekday operator/(const year_month& ym,
-                                    const weekday_indexed& wdi) NOEXCEPT {
-  return {ym.year(), ym.month(), wdi};
+inline
+year_month_weekday
+operator/(const year_month& ym, const weekday_indexed& wdi) NOEXCEPT
+{
+    return {ym.year(), ym.month(), wdi};
 }
 
 CONSTCD11
-inline year_month_weekday operator/(const year& y,
-                                    const month_weekday& mwd) NOEXCEPT {
-  return {y, mwd.month(), mwd.weekday_indexed()};
+inline
+year_month_weekday
+operator/(const year& y, const month_weekday& mwd) NOEXCEPT
+{
+    return {y, mwd.month(), mwd.weekday_indexed()};
 }
 
 CONSTCD11
-inline year_month_weekday operator/(int y, const month_weekday& mwd) NOEXCEPT {
-  return year(y) / mwd;
+inline
+year_month_weekday
+operator/(int y, const month_weekday& mwd) NOEXCEPT
+{
+    return year(y) / mwd;
 }
 
 CONSTCD11
-inline year_month_weekday operator/(const month_weekday& mwd,
-                                    const year& y) NOEXCEPT {
-  return y / mwd;
+inline
+year_month_weekday
+operator/(const month_weekday& mwd, const year& y) NOEXCEPT
+{
+    return y / mwd;
 }
 
 CONSTCD11
-inline year_month_weekday operator/(const month_weekday& mwd, int y) NOEXCEPT {
-  return year(y) / mwd;
+inline
+year_month_weekday
+operator/(const month_weekday& mwd, int y) NOEXCEPT
+{
+    return year(y) / mwd;
 }
 
 // year_month_weekday_last from operator/()
 
 CONSTCD11
-inline year_month_weekday_last operator/(const year_month& ym,
-                                         const weekday_last& wdl) NOEXCEPT {
-  return {ym.year(), ym.month(), wdl};
+inline
+year_month_weekday_last
+operator/(const year_month& ym, const weekday_last& wdl) NOEXCEPT
+{
+    return {ym.year(), ym.month(), wdl};
 }
 
 CONSTCD11
-inline year_month_weekday_last operator/(
-    const year& y, const month_weekday_last& mwdl) NOEXCEPT {
-  return {y, mwdl.month(), mwdl.weekday_last()};
+inline
+year_month_weekday_last
+operator/(const year& y, const month_weekday_last& mwdl) NOEXCEPT
+{
+    return {y, mwdl.month(), mwdl.weekday_last()};
 }
 
 CONSTCD11
-inline year_month_weekday_last operator/(
-    int y, const month_weekday_last& mwdl) NOEXCEPT {
-  return year(y) / mwdl;
+inline
+year_month_weekday_last
+operator/(int y, const month_weekday_last& mwdl) NOEXCEPT
+{
+    return year(y) / mwdl;
 }
 
 CONSTCD11
-inline year_month_weekday_last operator/(const month_weekday_last& mwdl,
-                                         const year& y) NOEXCEPT {
-  return y / mwdl;
+inline
+year_month_weekday_last
+operator/(const month_weekday_last& mwdl, const year& y) NOEXCEPT
+{
+    return y / mwdl;
 }
 
 CONSTCD11
-inline year_month_weekday_last operator/(const month_weekday_last& mwdl,
-                                         int y) NOEXCEPT {
-  return year(y) / mwdl;
+inline
+year_month_weekday_last
+operator/(const month_weekday_last& mwdl, int y) NOEXCEPT
+{
+    return year(y) / mwdl;
 }
 
 template <class Duration>
 struct fields;
 
 template <class CharT, class Traits, class Duration>
-std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const fields<Duration>& fds, const std::string* abbrev = nullptr,
-    const std::chrono::seconds* offset_sec = nullptr);
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const fields<Duration>& fds, const std::string* abbrev = nullptr,
+          const std::chrono::seconds* offset_sec = nullptr);
 
 template <class CharT, class Traits, class Duration, class Alloc>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    fields<Duration>& fds,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr);
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            fields<Duration>& fds, std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr);
 
 // hh_mm_ss
 
-namespace detail {
+namespace detail
+{
 
-struct undocumented {
-  explicit undocumented() = default;
-};
+struct undocumented {explicit undocumented() = default;};
 
 // width<n>::value is the number of fractional decimal digits in 1/n
 // width<0>::value and width<1>::value are defined to be 0
@@ -3230,608 +3917,860 @@ struct undocumented {
 // Example:  width<10>::value   ==  1
 // Example:  width<1000>::value ==  3
 template <std::uint64_t n, std::uint64_t d, unsigned w = 0,
-          bool should_continue = n % d != 0 && (w < 19)>
-struct width {
-  static_assert(d > 0, "width called with zero denominator");
-  static CONSTDATA unsigned value = 1 + width<n % d * 10, d, w + 1>::value;
+          bool should_continue = n%d != 0 && (w < 19)>
+struct width
+{
+    static_assert(d > 0, "width called with zero denominator");
+    static CONSTDATA unsigned value = 1 + width<n%d*10, d, w+1>::value;
 };
 
 template <std::uint64_t n, std::uint64_t d, unsigned w>
-struct width<n, d, w, false> {
-  static CONSTDATA unsigned value = 0;
+struct width<n, d, w, false>
+{
+    static CONSTDATA unsigned value = 0;
 };
 
 template <unsigned exp>
-struct static_pow10 {
- private:
-  static CONSTDATA std::uint64_t h = static_pow10<exp / 2>::value;
-
- public:
-  static CONSTDATA std::uint64_t value = h * h * (exp % 2 ? 10 : 1);
+struct static_pow10
+{
+private:
+    static CONSTDATA std::uint64_t h = static_pow10<exp/2>::value;
+public:
+    static CONSTDATA std::uint64_t value = h * h * (exp % 2 ? 10 : 1);
 };
 
 template <>
-struct static_pow10<0> {
-  static CONSTDATA std::uint64_t value = 1;
+struct static_pow10<0>
+{
+    static CONSTDATA std::uint64_t value = 1;
 };
 
 template <class Duration>
-class decimal_format_seconds {
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  using rep = typename CT::rep;
-  static unsigned CONSTDATA trial_width =
-      detail::width<CT::period::num, CT::period::den>::value;
+class decimal_format_seconds
+{
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    using rep = typename CT::rep;
+    static unsigned CONSTDATA trial_width =
+        detail::width<CT::period::num, CT::period::den>::value;
+public:
+    static unsigned CONSTDATA width = trial_width < 19 ? trial_width : 6u;
+    using precision = std::chrono::duration<rep,
+                                            std::ratio<1, static_pow10<width>::value>>;
 
- public:
-  static unsigned CONSTDATA width = trial_width < 19 ? trial_width : 6u;
-  using precision =
-      std::chrono::duration<rep, std::ratio<1, static_pow10<width>::value>>;
+private:
+    std::chrono::seconds s_;
+    precision            sub_s_;
 
- private:
-  std::chrono::seconds s_;
-  precision sub_s_;
+public:
+    CONSTCD11 decimal_format_seconds()
+        : s_()
+        , sub_s_()
+        {}
 
- public:
-  CONSTCD11 decimal_format_seconds() : s_(), sub_s_() {}
+    CONSTCD11 explicit decimal_format_seconds(const Duration& d) NOEXCEPT
+        : s_(std::chrono::duration_cast<std::chrono::seconds>(d))
+        , sub_s_(std::chrono::duration_cast<precision>(d - s_))
+        {}
 
-  CONSTCD11 explicit decimal_format_seconds(const Duration& d) NOEXCEPT
-      : s_(std::chrono::duration_cast<std::chrono::seconds>(d)),
-        sub_s_(std::chrono::duration_cast<precision>(d - s_)) {}
+    CONSTCD14 std::chrono::seconds& seconds() NOEXCEPT {return s_;}
+    CONSTCD11 std::chrono::seconds seconds() const NOEXCEPT {return s_;}
+    CONSTCD11 precision subseconds() const NOEXCEPT {return sub_s_;}
 
-  CONSTCD14 std::chrono::seconds& seconds() NOEXCEPT { return s_; }
-  CONSTCD11 std::chrono::seconds seconds() const NOEXCEPT { return s_; }
-  CONSTCD11 precision subseconds() const NOEXCEPT { return sub_s_; }
-
-  CONSTCD14 precision to_duration() const NOEXCEPT { return s_ + sub_s_; }
-
-  CONSTCD11 bool in_conventional_range() const NOEXCEPT {
-    return sub_s_ < std::chrono::seconds{1} && s_ < std::chrono::minutes{1};
-  }
-
-  template <class CharT, class Traits>
-  friend std::basic_ostream<CharT, Traits>& operator<<(
-      std::basic_ostream<CharT, Traits>& os, const decimal_format_seconds& x) {
-    return x.print(os, std::chrono::treat_as_floating_point<rep>{});
-  }
-
-  template <class CharT, class Traits>
-  std::basic_ostream<CharT, Traits>& print(
-      std::basic_ostream<CharT, Traits>& os, std::true_type) const {
-    date::detail::save_ostream<CharT, Traits> _(os);
-    std::chrono::duration<rep> d = s_ + sub_s_;
-    if (d < std::chrono::seconds{10}) os << '0';
-    os.precision(width + 6);
-    os << std::fixed << d.count();
-    return os;
-  }
-
-  template <class CharT, class Traits>
-  std::basic_ostream<CharT, Traits>& print(
-      std::basic_ostream<CharT, Traits>& os, std::false_type) const {
-    date::detail::save_ostream<CharT, Traits> _(os);
-    os.fill('0');
-    os.flags(std::ios::dec | std::ios::right);
-    os.width(2);
-    os << s_.count();
-    if (width > 0) {
-#if !ONLY_C_LOCALE
-      os << std::use_facet<std::numpunct<CharT>>(os.getloc()).decimal_point();
-#else
-      os << '.';
-#endif
-      date::detail::save_ostream<CharT, Traits> _s(os);
-      os.imbue(std::locale::classic());
-      os.width(width);
-      os << sub_s_.count();
+    CONSTCD14 precision to_duration() const NOEXCEPT
+    {
+        return s_ + sub_s_;
     }
-    return os;
-  }
+
+    CONSTCD11 bool in_conventional_range() const NOEXCEPT
+    {
+        return sub_s_ < std::chrono::seconds{1} && s_ < std::chrono::minutes{1};
+    }
+
+    template <class CharT, class Traits>
+    friend
+    std::basic_ostream<CharT, Traits>&
+    operator<<(std::basic_ostream<CharT, Traits>& os, const decimal_format_seconds& x)
+    {
+        return x.print(os, std::chrono::treat_as_floating_point<rep>{});
+    }
+
+    template <class CharT, class Traits>
+    std::basic_ostream<CharT, Traits>&
+    print(std::basic_ostream<CharT, Traits>& os, std::true_type) const
+    {
+        date::detail::save_ostream<CharT, Traits> _(os);
+        std::chrono::duration<rep> d = s_ + sub_s_;
+        if (d < std::chrono::seconds{10})
+            os << '0';
+        os.precision(width+6);
+        os << std::fixed << d.count();
+        return os;
+    }
+
+    template <class CharT, class Traits>
+    std::basic_ostream<CharT, Traits>&
+    print(std::basic_ostream<CharT, Traits>& os, std::false_type) const
+    {
+        date::detail::save_ostream<CharT, Traits> _(os);
+        os.fill('0');
+        os.flags(std::ios::dec | std::ios::right);
+        os.width(2);
+        os << s_.count();
+        if (width > 0)
+        {
+#if !ONLY_C_LOCALE
+            os << std::use_facet<std::numpunct<CharT>>(os.getloc()).decimal_point();
+#else
+            os << '.';
+#endif
+            date::detail::save_ostream<CharT, Traits> _s(os);
+            os.imbue(std::locale::classic());
+            os.width(width);
+            os << sub_s_.count();
+        }
+        return os;
+    }
 };
 
 template <class Rep, class Period>
-inline CONSTCD11
-    typename std::enable_if<std::numeric_limits<Rep>::is_signed,
-                            std::chrono::duration<Rep, Period>>::type
-    abs(std::chrono::duration<Rep, Period> d) {
-  return d >= d.zero() ? +d : -d;
+inline
+CONSTCD11
+typename std::enable_if
+         <
+            std::numeric_limits<Rep>::is_signed,
+            std::chrono::duration<Rep, Period>
+         >::type
+abs(std::chrono::duration<Rep, Period> d)
+{
+    return d >= d.zero() ? +d : -d;
 }
 
 template <class Rep, class Period>
-inline CONSTCD11
-    typename std::enable_if<!std::numeric_limits<Rep>::is_signed,
-                            std::chrono::duration<Rep, Period>>::type
-    abs(std::chrono::duration<Rep, Period> d) {
-  return d;
+inline
+CONSTCD11
+typename std::enable_if
+         <
+            !std::numeric_limits<Rep>::is_signed,
+            std::chrono::duration<Rep, Period>
+         >::type
+abs(std::chrono::duration<Rep, Period> d)
+{
+    return d;
 }
 
 }  // namespace detail
 
 template <class Duration>
-class hh_mm_ss {
-  using dfs = detail::decimal_format_seconds<
-      typename std::common_type<Duration, std::chrono::seconds>::type>;
+class hh_mm_ss
+{
+    using dfs = detail::decimal_format_seconds<typename std::common_type<Duration,
+                                               std::chrono::seconds>::type>;
 
-  std::chrono::hours h_;
-  std::chrono::minutes m_;
-  dfs s_;
-  bool neg_;
+    std::chrono::hours h_;
+    std::chrono::minutes m_;
+    dfs s_;
+    bool neg_;
 
- public:
-  static unsigned CONSTDATA fractional_width = dfs::width;
-  using precision = typename dfs::precision;
+public:
+    static unsigned CONSTDATA fractional_width = dfs::width;
+    using precision = typename dfs::precision;
 
-  CONSTCD11 hh_mm_ss() NOEXCEPT : hh_mm_ss(Duration::zero()) {}
+    CONSTCD11 hh_mm_ss() NOEXCEPT
+        : hh_mm_ss(Duration::zero())
+        {}
 
-  CONSTCD11 explicit hh_mm_ss(Duration d) NOEXCEPT
-      : h_(std::chrono::duration_cast<std::chrono::hours>(detail::abs(d))),
-        m_(std::chrono::duration_cast<std::chrono::minutes>(detail::abs(d)) -
-           h_),
-        s_(detail::abs(d) - h_ - m_),
-        neg_(d < Duration::zero()) {}
+    CONSTCD11 explicit hh_mm_ss(Duration d) NOEXCEPT
+        : h_(std::chrono::duration_cast<std::chrono::hours>(detail::abs(d)))
+        , m_(std::chrono::duration_cast<std::chrono::minutes>(detail::abs(d)) - h_)
+        , s_(detail::abs(d) - h_ - m_)
+        , neg_(d < Duration::zero())
+        {}
 
-  CONSTCD11 std::chrono::hours hours() const NOEXCEPT { return h_; }
-  CONSTCD11 std::chrono::minutes minutes() const NOEXCEPT { return m_; }
-  CONSTCD11 std::chrono::seconds seconds() const NOEXCEPT {
-    return s_.seconds();
-  }
-  CONSTCD14 std::chrono::seconds& seconds(detail::undocumented) NOEXCEPT {
-    return s_.seconds();
-  }
-  CONSTCD11 precision subseconds() const NOEXCEPT { return s_.subseconds(); }
-  CONSTCD11 bool is_negative() const NOEXCEPT { return neg_; }
+    CONSTCD11 std::chrono::hours hours() const NOEXCEPT {return h_;}
+    CONSTCD11 std::chrono::minutes minutes() const NOEXCEPT {return m_;}
+    CONSTCD11 std::chrono::seconds seconds() const NOEXCEPT {return s_.seconds();}
+    CONSTCD14 std::chrono::seconds&
+        seconds(detail::undocumented) NOEXCEPT {return s_.seconds();}
+    CONSTCD11 precision subseconds() const NOEXCEPT {return s_.subseconds();}
+    CONSTCD11 bool is_negative() const NOEXCEPT {return neg_;}
 
-  CONSTCD11 explicit operator precision() const NOEXCEPT {
-    return to_duration();
-  }
-  CONSTCD11 precision to_duration() const NOEXCEPT {
-    return (s_.to_duration() + m_ + h_) * (1 - 2 * neg_);
-  }
+    CONSTCD11 explicit operator  precision()   const NOEXCEPT {return to_duration();}
+    CONSTCD11          precision to_duration() const NOEXCEPT
+        {return (s_.to_duration() + m_ + h_) * (1-2*neg_);}
 
-  CONSTCD11 bool in_conventional_range() const NOEXCEPT {
-    return !neg_ && h_ < days{1} && m_ < std::chrono::hours{1} &&
-           s_.in_conventional_range();
-  }
+    CONSTCD11 bool in_conventional_range() const NOEXCEPT
+    {
+        return !neg_ && h_ < days{1} && m_ < std::chrono::hours{1} &&
+               s_.in_conventional_range();
+    }
 
- private:
-  template <class charT, class traits>
-  friend std::basic_ostream<charT, traits>& operator<<(
-      std::basic_ostream<charT, traits>& os, hh_mm_ss const& tod) {
-    if (tod.is_negative()) os << '-';
-    if (tod.h_ < std::chrono::hours{10}) os << '0';
-    os << tod.h_.count() << ':';
-    if (tod.m_ < std::chrono::minutes{10}) os << '0';
-    os << tod.m_.count() << ':' << tod.s_;
-    return os;
-  }
+private:
 
-  template <class CharT, class Traits, class Duration2>
-  friend std::basic_ostream<CharT, Traits>& date::to_stream(
-      std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-      const fields<Duration2>& fds, const std::string* abbrev,
-      const std::chrono::seconds* offset_sec);
+    template <class charT, class traits>
+    friend
+    std::basic_ostream<charT, traits>&
+    operator<<(std::basic_ostream<charT, traits>& os, hh_mm_ss const& tod)
+    {
+        if (tod.is_negative())
+            os << '-';
+        if (tod.h_ < std::chrono::hours{10})
+            os << '0';
+        os << tod.h_.count() << ':';
+        if (tod.m_ < std::chrono::minutes{10})
+            os << '0';
+        os << tod.m_.count() << ':' << tod.s_;
+        return os;
+    }
 
-  template <class CharT, class Traits, class Duration2, class Alloc>
-  friend std::basic_istream<CharT, Traits>& date::from_stream(
-      std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-      fields<Duration2>& fds, std::basic_string<CharT, Traits, Alloc>* abbrev,
-      std::chrono::minutes* offset);
+    template <class CharT, class Traits, class Duration2>
+    friend
+    std::basic_ostream<CharT, Traits>&
+    date::to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const fields<Duration2>& fds, const std::string* abbrev,
+          const std::chrono::seconds* offset_sec);
+
+    template <class CharT, class Traits, class Duration2, class Alloc>
+    friend
+    std::basic_istream<CharT, Traits>&
+    date::from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+          fields<Duration2>& fds,
+          std::basic_string<CharT, Traits, Alloc>* abbrev, std::chrono::minutes* offset);
 };
 
-inline CONSTCD14 bool is_am(std::chrono::hours const& h) NOEXCEPT {
-  using std::chrono::hours;
-  return hours{0} <= h && h < hours{12};
+inline
+CONSTCD14
+bool
+is_am(std::chrono::hours const& h) NOEXCEPT
+{
+    using std::chrono::hours;
+    return hours{0} <= h && h < hours{12};
 }
 
-inline CONSTCD14 bool is_pm(std::chrono::hours const& h) NOEXCEPT {
-  using std::chrono::hours;
-  return hours{12} <= h && h < hours{24};
+inline
+CONSTCD14
+bool
+is_pm(std::chrono::hours const& h) NOEXCEPT
+{
+    using std::chrono::hours;
+    return hours{12} <= h && h < hours{24};
 }
 
-inline CONSTCD14 std::chrono::hours make12(std::chrono::hours h) NOEXCEPT {
-  using std::chrono::hours;
-  if (h < hours{12}) {
-    if (h == hours{0}) h = hours{12};
-  } else {
-    if (h != hours{12}) h = h - hours{12};
-  }
-  return h;
+inline
+CONSTCD14
+std::chrono::hours
+make12(std::chrono::hours h) NOEXCEPT
+{
+    using std::chrono::hours;
+    if (h < hours{12})
+    {
+        if (h == hours{0})
+            h = hours{12};
+    }
+    else
+    {
+        if (h != hours{12})
+            h = h - hours{12};
+    }
+    return h;
 }
 
-inline CONSTCD14 std::chrono::hours make24(std::chrono::hours h,
-                                           bool is_pm) NOEXCEPT {
-  using std::chrono::hours;
-  if (is_pm) {
-    if (h != hours{12}) h = h + hours{12};
-  } else if (h == hours{12})
-    h = hours{0};
-  return h;
+inline
+CONSTCD14
+std::chrono::hours
+make24(std::chrono::hours h, bool is_pm) NOEXCEPT
+{
+    using std::chrono::hours;
+    if (is_pm)
+    {
+        if (h != hours{12})
+            h = h + hours{12};
+    }
+    else if (h == hours{12})
+        h = hours{0};
+    return h;
 }
 
 template <class Duration>
 using time_of_day = hh_mm_ss<Duration>;
 
 template <class Rep, class Period>
-CONSTCD11 inline hh_mm_ss<std::chrono::duration<Rep, Period>> make_time(
-    const std::chrono::duration<Rep, Period>& d) {
-  return hh_mm_ss<std::chrono::duration<Rep, Period>>(d);
+CONSTCD11
+inline
+hh_mm_ss<std::chrono::duration<Rep, Period>>
+make_time(const std::chrono::duration<Rep, Period>& d)
+{
+    return hh_mm_ss<std::chrono::duration<Rep, Period>>(d);
 }
 
 template <class CharT, class Traits, class Duration>
-inline typename std::enable_if<
-    std::ratio_less<typename Duration::period, days::period>::value,
-    std::basic_ostream<CharT, Traits>&>::type
-operator<<(std::basic_ostream<CharT, Traits>& os,
-           const sys_time<Duration>& tp) {
-  auto const dp = date::floor<days>(tp);
-  return os << year_month_day(dp) << ' ' << make_time(tp - dp);
+inline
+typename std::enable_if
+<
+    !std::is_convertible<Duration, days>::value,
+    std::basic_ostream<CharT, Traits>&
+>::type
+operator<<(std::basic_ostream<CharT, Traits>& os, const sys_time<Duration>& tp)
+{
+    auto const dp = date::floor<days>(tp);
+    return os << year_month_day(dp) << ' ' << make_time(tp-dp);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const sys_days& dp) {
-  return os << year_month_day(dp);
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const sys_days& dp)
+{
+    return os << year_month_day(dp);
 }
 
 template <class CharT, class Traits, class Duration>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os, const local_time<Duration>& ut) {
-  return (os << sys_time<Duration>{ut.time_since_epoch()});
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os, const local_time<Duration>& ut)
+{
+    return (os << sys_time<Duration>{ut.time_since_epoch()});
 }
 
-namespace detail {
+namespace detail
+{
 
 template <class CharT, std::size_t N>
 class string_literal;
 
 template <class CharT1, class CharT2, std::size_t N1, std::size_t N2>
-inline CONSTCD14
-    string_literal<typename std::conditional<sizeof(CharT2) <= sizeof(CharT1),
-                                             CharT1, CharT2>::type,
-                   N1 + N2 - 1>
-    operator+(const string_literal<CharT1, N1>& x,
-              const string_literal<CharT2, N2>& y) NOEXCEPT;
+inline
+CONSTCD14
+string_literal<typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1, CharT2>::type,
+               N1 + N2 - 1>
+operator+(const string_literal<CharT1, N1>& x, const string_literal<CharT2, N2>& y) NOEXCEPT;
 
 template <class CharT, std::size_t N>
-class string_literal {
-  CharT p_[N];
+class string_literal
+{
+    CharT p_[N];
 
-  CONSTCD11 string_literal() NOEXCEPT : p_{} {}
+    CONSTCD11 string_literal() NOEXCEPT
+      : p_{}
+    {}
 
- public:
-  using const_iterator = const CharT*;
+public:
+    using const_iterator = const CharT*;
 
-  string_literal(string_literal const&) = default;
-  string_literal& operator=(string_literal const&) = delete;
+    string_literal(string_literal const&) = default;
+    string_literal& operator=(string_literal const&) = delete;
 
-  template <std::size_t N1 = 2, class = typename std::enable_if<N1 == N>::type>
-  CONSTCD11 string_literal(CharT c) NOEXCEPT : p_{c} {}
+    template <std::size_t N1 = 2,
+              class = typename std::enable_if<N1 == N>::type>
+    CONSTCD11 string_literal(CharT c) NOEXCEPT
+        : p_{c}
+    {
+    }
 
-  template <std::size_t N1 = 3, class = typename std::enable_if<N1 == N>::type>
-  CONSTCD11 string_literal(CharT c1, CharT c2) NOEXCEPT : p_{c1, c2} {}
+    template <std::size_t N1 = 3,
+              class = typename std::enable_if<N1 == N>::type>
+    CONSTCD11 string_literal(CharT c1, CharT c2) NOEXCEPT
+        : p_{c1, c2}
+    {
+    }
 
-  template <std::size_t N1 = 4, class = typename std::enable_if<N1 == N>::type>
-  CONSTCD11 string_literal(CharT c1, CharT c2, CharT c3) NOEXCEPT
-      : p_{c1, c2, c3} {}
+    template <std::size_t N1 = 4,
+              class = typename std::enable_if<N1 == N>::type>
+    CONSTCD11 string_literal(CharT c1, CharT c2, CharT c3) NOEXCEPT
+        : p_{c1, c2, c3}
+    {
+    }
 
-  CONSTCD14 string_literal(const CharT (&a)[N]) NOEXCEPT : p_{} {
-    for (std::size_t i = 0; i < N; ++i) p_[i] = a[i];
-  }
+    CONSTCD14 string_literal(const CharT(&a)[N]) NOEXCEPT
+        : p_{}
+    {
+        for (std::size_t i = 0; i < N; ++i)
+            p_[i] = a[i];
+    }
 
-  template <class U = CharT,
-            class = typename std::enable_if<(1 < sizeof(U))>::type>
-  CONSTCD14 string_literal(const char (&a)[N]) NOEXCEPT : p_{} {
-    for (std::size_t i = 0; i < N; ++i) p_[i] = a[i];
-  }
+    template <class U = CharT,
+              class = typename std::enable_if<(1 < sizeof(U))>::type>
+    CONSTCD14 string_literal(const char(&a)[N]) NOEXCEPT
+        : p_{}
+    {
+        for (std::size_t i = 0; i < N; ++i)
+            p_[i] = a[i];
+    }
 
-  template <class CharT2, class = typename std::enable_if<
-                              !std::is_same<CharT2, CharT>::value>::type>
-  CONSTCD14 string_literal(string_literal<CharT2, N> const& a) NOEXCEPT : p_{} {
-    for (std::size_t i = 0; i < N; ++i) p_[i] = a[i];
-  }
+    template <class CharT2,
+              class = typename std::enable_if<!std::is_same<CharT2, CharT>::value>::type>
+    CONSTCD14 string_literal(string_literal<CharT2, N> const& a) NOEXCEPT
+        : p_{}
+    {
+        for (std::size_t i = 0; i < N; ++i)
+            p_[i] = a[i];
+    }
 
-  CONSTCD11 const CharT* data() const NOEXCEPT { return p_; }
-  CONSTCD11 std::size_t size() const NOEXCEPT { return N - 1; }
+    CONSTCD11 const CharT* data() const NOEXCEPT {return p_;}
+    CONSTCD11 std::size_t size() const NOEXCEPT {return N-1;}
 
-  CONSTCD11 const_iterator begin() const NOEXCEPT { return p_; }
-  CONSTCD11 const_iterator end() const NOEXCEPT { return p_ + N - 1; }
+    CONSTCD11 const_iterator begin() const NOEXCEPT {return p_;}
+    CONSTCD11 const_iterator end()   const NOEXCEPT {return p_ + N-1;}
 
-  CONSTCD11 CharT const& operator[](std::size_t n) const NOEXCEPT {
-    return p_[n];
-  }
+    CONSTCD11 CharT const& operator[](std::size_t n) const NOEXCEPT
+    {
+        return p_[n];
+    }
 
-  template <class Traits>
-  friend std::basic_ostream<CharT, Traits>& operator<<(
-      std::basic_ostream<CharT, Traits>& os, const string_literal& s) {
-    return os << s.p_;
-  }
+    template <class Traits>
+    friend
+    std::basic_ostream<CharT, Traits>&
+    operator<<(std::basic_ostream<CharT, Traits>& os, const string_literal& s)
+    {
+        return os << s.p_;
+    }
 
-  template <class CharT1, class CharT2, std::size_t N1, std::size_t N2>
-  friend CONSTCD14
-      string_literal<typename std::conditional<sizeof(CharT2) <= sizeof(CharT1),
-                                               CharT1, CharT2>::type,
-                     N1 + N2 - 1>
-      operator+(const string_literal<CharT1, N1>& x,
-                const string_literal<CharT2, N2>& y) NOEXCEPT;
+    template <class CharT1, class CharT2, std::size_t N1, std::size_t N2>
+    friend
+    CONSTCD14
+    string_literal<typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1, CharT2>::type,
+                   N1 + N2 - 1>
+    operator+(const string_literal<CharT1, N1>& x, const string_literal<CharT2, N2>& y) NOEXCEPT;
 };
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 3> operator+(
-    const string_literal<CharT, 2>& x,
-    const string_literal<CharT, 2>& y) NOEXCEPT {
+CONSTCD11
+inline
+string_literal<CharT, 3>
+operator+(const string_literal<CharT, 2>& x, const string_literal<CharT, 2>& y) NOEXCEPT
+{
   return string_literal<CharT, 3>(x[0], y[0]);
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 4> operator+(
-    const string_literal<CharT, 3>& x,
-    const string_literal<CharT, 2>& y) NOEXCEPT {
+CONSTCD11
+inline
+string_literal<CharT, 4>
+operator+(const string_literal<CharT, 3>& x, const string_literal<CharT, 2>& y) NOEXCEPT
+{
   return string_literal<CharT, 4>(x[0], x[1], y[0]);
 }
 
 template <class CharT1, class CharT2, std::size_t N1, std::size_t N2>
-CONSTCD14 inline string_literal<
-    typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1,
-                              CharT2>::type,
-    N1 + N2 - 1>
-operator+(const string_literal<CharT1, N1>& x,
-          const string_literal<CharT2, N2>& y) NOEXCEPT {
-  using CT = typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1,
-                                       CharT2>::type;
+CONSTCD14
+inline
+string_literal<typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1, CharT2>::type,
+               N1 + N2 - 1>
+operator+(const string_literal<CharT1, N1>& x, const string_literal<CharT2, N2>& y) NOEXCEPT
+{
+    using CT = typename std::conditional<sizeof(CharT2) <= sizeof(CharT1), CharT1, CharT2>::type;
 
-  string_literal<CT, N1 + N2 - 1> r;
-  std::size_t i = 0;
-  for (; i < N1 - 1; ++i) r.p_[i] = CT(x.p_[i]);
-  for (std::size_t j = 0; j < N2; ++j, ++i) r.p_[i] = CT(y.p_[j]);
+    string_literal<CT, N1 + N2 - 1> r;
+    std::size_t i = 0;
+    for (; i < N1-1; ++i)
+       r.p_[i] = CT(x.p_[i]);
+    for (std::size_t j = 0; j < N2; ++j, ++i)
+       r.p_[i] = CT(y.p_[j]);
 
-  return r;
+    return r;
 }
+
 
 template <class CharT, class Traits, class Alloc, std::size_t N>
-inline std::basic_string<CharT, Traits, Alloc> operator+(
-    std::basic_string<CharT, Traits, Alloc> x,
-    const string_literal<CharT, N>& y) {
-  x.append(y.data(), y.size());
-  return x;
+inline
+std::basic_string<CharT, Traits, Alloc>
+operator+(std::basic_string<CharT, Traits, Alloc> x, const string_literal<CharT, N>& y)
+{
+    x.append(y.data(), y.size());
+    return x;
 }
 
-#if __cplusplus >= 201402 &&                                \
-    (!defined(__EDG_VERSION__) || __EDG_VERSION__ > 411) && \
-    (!defined(__SUNPRO_CC) || __SUNPRO_CC > 0x5150)
+#if __cplusplus >= 201402  && (!defined(__EDG_VERSION__) || __EDG_VERSION__ > 411) \
+                           && (!defined(__SUNPRO_CC) || __SUNPRO_CC > 0x5150)
 
 template <class CharT,
           class = std::enable_if_t<std::is_same<CharT, char>::value ||
                                    std::is_same<CharT, wchar_t>::value ||
                                    std::is_same<CharT, char16_t>::value ||
                                    std::is_same<CharT, char32_t>::value>>
-CONSTCD14 inline string_literal<CharT, 2> msl(CharT c) NOEXCEPT {
-  return string_literal<CharT, 2>{c};
+CONSTCD14
+inline
+string_literal<CharT, 2>
+msl(CharT c) NOEXCEPT
+{
+    return string_literal<CharT, 2>{c};
 }
 
 CONSTCD14
-inline std::size_t to_string_len(std::intmax_t i) {
-  std::size_t r = 0;
-  do {
-    i /= 10;
-    ++r;
-  } while (i > 0);
-  return r;
+inline
+std::size_t
+to_string_len(std::intmax_t i)
+{
+    std::size_t r = 0;
+    do
+    {
+        i /= 10;
+        ++r;
+    } while (i > 0);
+    return r;
 }
 
 template <std::intmax_t N>
-    CONSTCD14 inline std::enable_if_t <
-    N<10, string_literal<char, to_string_len(N) + 1>> msl() NOEXCEPT {
-  return msl(char(N % 10 + '0'));
+CONSTCD14
+inline
+std::enable_if_t
+<
+    N < 10,
+    string_literal<char, to_string_len(N)+1>
+>
+msl() NOEXCEPT
+{
+    return msl(char(N % 10 + '0'));
 }
 
 template <std::intmax_t N>
-CONSTCD14 inline std::enable_if_t<10 <= N,
-                                  string_literal<char, to_string_len(N) + 1>>
-msl() NOEXCEPT {
-  return msl<N / 10>() + msl(char(N % 10 + '0'));
+CONSTCD14
+inline
+std::enable_if_t
+<
+    10 <= N,
+    string_literal<char, to_string_len(N)+1>
+>
+msl() NOEXCEPT
+{
+    return msl<N/10>() + msl(char(N % 10 + '0'));
 }
 
 template <class CharT, std::intmax_t N, std::intmax_t D>
-CONSTCD14 inline std::enable_if_t<
+CONSTCD14
+inline
+std::enable_if_t
+<
     std::ratio<N, D>::type::den != 1,
     string_literal<CharT, to_string_len(std::ratio<N, D>::type::num) +
-                              to_string_len(std::ratio<N, D>::type::den) + 4>>
-msl(std::ratio<N, D>) NOEXCEPT {
-  using R = typename std::ratio<N, D>::type;
-  return msl(CharT{'['}) + msl<R::num>() + msl(CharT{'/'}) + msl<R::den>() +
-         msl(CharT{']'});
+                          to_string_len(std::ratio<N, D>::type::den) + 4>
+>
+msl(std::ratio<N, D>) NOEXCEPT
+{
+    using R = typename std::ratio<N, D>::type;
+    return msl(CharT{'['}) + msl<R::num>() + msl(CharT{'/'}) +
+                             msl<R::den>() + msl(CharT{']'});
 }
 
 template <class CharT, std::intmax_t N, std::intmax_t D>
-CONSTCD14 inline std::enable_if_t<
+CONSTCD14
+inline
+std::enable_if_t
+<
     std::ratio<N, D>::type::den == 1,
-    string_literal<CharT, to_string_len(std::ratio<N, D>::type::num) + 3>>
-msl(std::ratio<N, D>) NOEXCEPT {
-  using R = typename std::ratio<N, D>::type;
-  return msl(CharT{'['}) + msl<R::num>() + msl(CharT{']'});
+    string_literal<CharT, to_string_len(std::ratio<N, D>::type::num) + 3>
+>
+msl(std::ratio<N, D>) NOEXCEPT
+{
+    using R = typename std::ratio<N, D>::type;
+    return msl(CharT{'['}) + msl<R::num>() + msl(CharT{']'});
 }
 
-#else  // __cplusplus < 201402 || (defined(__EDG_VERSION__) && __EDG_VERSION__
-       // <= 411)
 
-inline std::string to_string(std::uint64_t x) { return std::to_string(x); }
+#else  // __cplusplus < 201402 || (defined(__EDG_VERSION__) && __EDG_VERSION__ <= 411)
+
+inline
+std::string
+to_string(std::uint64_t x)
+{
+    return std::to_string(x);
+}
 
 template <class CharT>
-inline std::basic_string<CharT> to_string(std::uint64_t x) {
-  auto y = std::to_string(x);
-  return std::basic_string<CharT>(y.begin(), y.end());
+inline
+std::basic_string<CharT>
+to_string(std::uint64_t x)
+{
+    auto y = std::to_string(x);
+    return std::basic_string<CharT>(y.begin(), y.end());
 }
 
 template <class CharT, std::intmax_t N, std::intmax_t D>
-inline typename std::enable_if<std::ratio<N, D>::type::den != 1,
-                               std::basic_string<CharT>>::type
-msl(std::ratio<N, D>) {
-  using R = typename std::ratio<N, D>::type;
-  return std::basic_string<CharT>(1, '[') + to_string<CharT>(R::num) +
-         CharT{'/'} + to_string<CharT>(R::den) + CharT{']'};
+inline
+typename std::enable_if
+<
+    std::ratio<N, D>::type::den != 1,
+    std::basic_string<CharT>
+>::type
+msl(std::ratio<N, D>)
+{
+    using R = typename std::ratio<N, D>::type;
+    return std::basic_string<CharT>(1, '[') + to_string<CharT>(R::num) + CharT{'/'} +
+                                              to_string<CharT>(R::den) + CharT{']'};
 }
 
 template <class CharT, std::intmax_t N, std::intmax_t D>
-inline typename std::enable_if<std::ratio<N, D>::type::den == 1,
-                               std::basic_string<CharT>>::type
-msl(std::ratio<N, D>) {
-  using R = typename std::ratio<N, D>::type;
-  return std::basic_string<CharT>(1, '[') + to_string<CharT>(R::num) +
-         CharT{']'};
+inline
+typename std::enable_if
+<
+    std::ratio<N, D>::type::den == 1,
+    std::basic_string<CharT>
+>::type
+msl(std::ratio<N, D>)
+{
+    using R = typename std::ratio<N, D>::type;
+    return std::basic_string<CharT>(1, '[') + to_string<CharT>(R::num) + CharT{']'};
 }
 
-#endif  // __cplusplus < 201402 || (defined(__EDG_VERSION__) && __EDG_VERSION__
-        // <= 411)
+#endif  // __cplusplus < 201402 || (defined(__EDG_VERSION__) && __EDG_VERSION__ <= 411)
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::atto) NOEXCEPT {
-  return string_literal<CharT, 2>{'a'};
-}
-
-template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::femto) NOEXCEPT {
-  return string_literal<CharT, 2>{'f'};
-}
-
-template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::pico) NOEXCEPT {
-  return string_literal<CharT, 2>{'p'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::atto) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'a'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::nano) NOEXCEPT {
-  return string_literal<CharT, 2>{'n'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::femto) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'f'};
 }
 
 template <class CharT>
-CONSTCD11 inline typename std::enable_if<std::is_same<CharT, char>::value,
-                                         string_literal<char, 3>>::type
-msl(std::micro) NOEXCEPT {
-  return string_literal<char, 3>{'\xC2', '\xB5'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::pico) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'p'};
 }
 
 template <class CharT>
-CONSTCD11 inline typename std::enable_if<!std::is_same<CharT, char>::value,
-                                         string_literal<CharT, 2>>::type
-msl(std::micro) NOEXCEPT {
-  return string_literal<CharT, 2>{CharT{static_cast<unsigned char>('\xB5')}};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::nano) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'n'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::milli) NOEXCEPT {
-  return string_literal<CharT, 2>{'m'};
+CONSTCD11
+inline
+typename std::enable_if
+<
+    std::is_same<CharT, char>::value,
+    string_literal<char, 3>
+>::type
+msl(std::micro) NOEXCEPT
+{
+    return string_literal<char, 3>{'\xC2', '\xB5'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::centi) NOEXCEPT {
-  return string_literal<CharT, 2>{'c'};
+CONSTCD11
+inline
+typename std::enable_if
+<
+    !std::is_same<CharT, char>::value,
+    string_literal<CharT, 2>
+>::type
+msl(std::micro) NOEXCEPT
+{
+    return string_literal<CharT, 2>{CharT{static_cast<unsigned char>('\xB5')}};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 3> msl(std::deca) NOEXCEPT {
-  return string_literal<CharT, 3>{'d', 'a'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::milli) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'m'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::deci) NOEXCEPT {
-  return string_literal<CharT, 2>{'d'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::centi) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'c'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::hecto) NOEXCEPT {
-  return string_literal<CharT, 2>{'h'};
+CONSTCD11
+inline
+string_literal<CharT, 3>
+msl(std::deca) NOEXCEPT
+{
+    return string_literal<CharT, 3>{'d', 'a'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::kilo) NOEXCEPT {
-  return string_literal<CharT, 2>{'k'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::deci) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'d'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::mega) NOEXCEPT {
-  return string_literal<CharT, 2>{'M'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::hecto) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'h'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::giga) NOEXCEPT {
-  return string_literal<CharT, 2>{'G'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::kilo) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'k'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::tera) NOEXCEPT {
-  return string_literal<CharT, 2>{'T'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::mega) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'M'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::peta) NOEXCEPT {
-  return string_literal<CharT, 2>{'P'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::giga) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'G'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> msl(std::exa) NOEXCEPT {
-  return string_literal<CharT, 2>{'E'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::tera) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'T'};
+}
+
+template <class CharT>
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::peta) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'P'};
+}
+
+template <class CharT>
+CONSTCD11
+inline
+string_literal<CharT, 2>
+msl(std::exa) NOEXCEPT
+{
+    return string_literal<CharT, 2>{'E'};
 }
 
 template <class CharT, class Period>
-CONSTCD11 inline auto get_units(Period p)
-    -> decltype(msl<CharT>(p) + string_literal<CharT, 2>{'s'}) {
-  return msl<CharT>(p) + string_literal<CharT, 2>{'s'};
+CONSTCD11
+inline
+auto
+get_units(Period p)
+ -> decltype(msl<CharT>(p) + string_literal<CharT, 2>{'s'})
+{
+    return msl<CharT>(p) + string_literal<CharT, 2>{'s'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> get_units(std::ratio<1>) {
-  return string_literal<CharT, 2>{'s'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+get_units(std::ratio<1>)
+{
+    return string_literal<CharT, 2>{'s'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> get_units(std::ratio<3600>) {
-  return string_literal<CharT, 2>{'h'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+get_units(std::ratio<3600>)
+{
+    return string_literal<CharT, 2>{'h'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 4> get_units(std::ratio<60>) {
-  return string_literal<CharT, 4>{'m', 'i', 'n'};
+CONSTCD11
+inline
+string_literal<CharT, 4>
+get_units(std::ratio<60>)
+{
+    return string_literal<CharT, 4>{'m', 'i', 'n'};
 }
 
 template <class CharT>
-CONSTCD11 inline string_literal<CharT, 2> get_units(std::ratio<86400>) {
-  return string_literal<CharT, 2>{'d'};
+CONSTCD11
+inline
+string_literal<CharT, 2>
+get_units(std::ratio<86400>)
+{
+    return string_literal<CharT, 2>{'d'};
 }
 
 template <class CharT, class Traits = std::char_traits<CharT>>
 struct make_string;
 
 template <>
-struct make_string<char> {
-  template <class Rep>
-  static std::string from(Rep n) {
-    return std::to_string(n);
-  }
+struct make_string<char>
+{
+    template <class Rep>
+    static
+    std::string
+    from(Rep n)
+    {
+        return std::to_string(n);
+    }
 };
 
 template <class Traits>
-struct make_string<char, Traits> {
-  template <class Rep>
-  static std::basic_string<char, Traits> from(Rep n) {
-    auto s = std::to_string(n);
-    return std::basic_string<char, Traits>(s.begin(), s.end());
-  }
+struct make_string<char, Traits>
+{
+    template <class Rep>
+    static
+    std::basic_string<char, Traits>
+    from(Rep n)
+    {
+        auto s = std::to_string(n);
+        return std::basic_string<char, Traits>(s.begin(), s.end());
+    }
 };
 
 template <>
-struct make_string<wchar_t> {
-  template <class Rep>
-  static std::wstring from(Rep n) {
-    return std::to_wstring(n);
-  }
+struct make_string<wchar_t>
+{
+    template <class Rep>
+    static
+    std::wstring
+    from(Rep n)
+    {
+        return std::to_wstring(n);
+    }
 };
 
 template <class Traits>
-struct make_string<wchar_t, Traits> {
-  template <class Rep>
-  static std::basic_string<wchar_t, Traits> from(Rep n) {
-    auto s = std::to_wstring(n);
-    return std::basic_string<wchar_t, Traits>(s.begin(), s.end());
-  }
+struct make_string<wchar_t, Traits>
+{
+    template <class Rep>
+    static
+    std::basic_string<wchar_t, Traits>
+    from(Rep n)
+    {
+        auto s = std::to_wstring(n);
+        return std::basic_string<wchar_t, Traits>(s.begin(), s.end());
+    }
 };
 
 }  // namespace detail
@@ -3841,181 +4780,258 @@ struct make_string<wchar_t, Traits> {
 CONSTDATA year nanyear{-32768};
 
 template <class Duration>
-struct fields {
-  year_month_day ymd{nanyear / 0 / 0};
-  weekday wd{8u};
-  hh_mm_ss<Duration> tod{};
-  bool has_tod = false;
+struct fields
+{
+    year_month_day        ymd{nanyear/0/0};
+    weekday               wd{8u};
+    hh_mm_ss<Duration>    tod{};
+    bool                  has_tod = false;
 
-#if !defined(__clang__) && defined(__GNUC__) && \
-    (__GNUC__ * 100 + __GNUC_MINOR__ <= 409)
-  fields() : ymd{nanyear / 0 / 0}, wd{8u}, tod{}, has_tod{false} {}
+#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ <= 409)
+    fields() : ymd{nanyear/0/0}, wd{8u}, tod{}, has_tod{false} {}
 #else
-  fields() = default;
+    fields() = default;
 #endif
 
-  fields(year_month_day ymd_) : ymd(ymd_) {}
-  fields(weekday wd_) : wd(wd_) {}
-  fields(hh_mm_ss<Duration> tod_) : tod(tod_), has_tod(true) {}
+    fields(year_month_day ymd_) : ymd(ymd_) {}
+    fields(weekday wd_) : wd(wd_) {}
+    fields(hh_mm_ss<Duration> tod_) : tod(tod_), has_tod(true) {}
 
-  fields(year_month_day ymd_, weekday wd_) : ymd(ymd_), wd(wd_) {}
-  fields(year_month_day ymd_, hh_mm_ss<Duration> tod_)
-      : ymd(ymd_), tod(tod_), has_tod(true) {}
+    fields(year_month_day ymd_, weekday wd_) : ymd(ymd_), wd(wd_) {}
+    fields(year_month_day ymd_, hh_mm_ss<Duration> tod_) : ymd(ymd_), tod(tod_),
+                                                           has_tod(true) {}
 
-  fields(weekday wd_, hh_mm_ss<Duration> tod_)
-      : wd(wd_), tod(tod_), has_tod(true) {}
+    fields(weekday wd_, hh_mm_ss<Duration> tod_) : wd(wd_), tod(tod_), has_tod(true) {}
 
-  fields(year_month_day ymd_, weekday wd_, hh_mm_ss<Duration> tod_)
-      : ymd(ymd_), wd(wd_), tod(tod_), has_tod(true) {}
+    fields(year_month_day ymd_, weekday wd_, hh_mm_ss<Duration> tod_)
+        : ymd(ymd_)
+        , wd(wd_)
+        , tod(tod_)
+        , has_tod(true)
+        {}
 };
 
-namespace detail {
+namespace detail
+{
 
 template <class CharT, class Traits, class Duration>
-unsigned extract_weekday(std::basic_ostream<CharT, Traits>& os,
-                         const fields<Duration>& fds) {
-  if (!fds.ymd.ok() && !fds.wd.ok()) {
-    // fds does not contain a valid weekday
-    os.setstate(std::ios::failbit);
-    return 8;
-  }
-  weekday wd;
-  if (fds.ymd.ok()) {
-    wd = weekday{sys_days(fds.ymd)};
-    if (fds.wd.ok() && wd != fds.wd) {
-      // fds.ymd and fds.wd are inconsistent
-      os.setstate(std::ios::failbit);
-      return 8;
+unsigned
+extract_weekday(std::basic_ostream<CharT, Traits>& os, const fields<Duration>& fds)
+{
+    if (!fds.ymd.ok() && !fds.wd.ok())
+    {
+        // fds does not contain a valid weekday
+        os.setstate(std::ios::failbit);
+        return 8;
     }
-  } else
-    wd = fds.wd;
-  return static_cast<unsigned>((wd - Sunday).count());
+    weekday wd;
+    if (fds.ymd.ok())
+    {
+        wd = weekday{sys_days(fds.ymd)};
+        if (fds.wd.ok() && wd != fds.wd)
+        {
+            // fds.ymd and fds.wd are inconsistent
+            os.setstate(std::ios::failbit);
+            return 8;
+        }
+    }
+    else
+        wd = fds.wd;
+    return static_cast<unsigned>((wd - Sunday).count());
 }
 
 template <class CharT, class Traits, class Duration>
-unsigned extract_month(std::basic_ostream<CharT, Traits>& os,
-                       const fields<Duration>& fds) {
-  if (!fds.ymd.month().ok()) {
-    // fds does not contain a valid month
-    os.setstate(std::ios::failbit);
-    return 0;
-  }
-  return static_cast<unsigned>(fds.ymd.month());
+unsigned
+extract_month(std::basic_ostream<CharT, Traits>& os, const fields<Duration>& fds)
+{
+    if (!fds.ymd.month().ok())
+    {
+        // fds does not contain a valid month
+        os.setstate(std::ios::failbit);
+        return 0;
+    }
+    return static_cast<unsigned>(fds.ymd.month());
 }
 
 }  // namespace detail
 
 #if ONLY_C_LOCALE
 
-namespace detail {
+namespace detail
+{
 
-inline std::pair<const std::string*, const std::string*> weekday_names() {
-  static const std::string nm[] = {
-      "Sunday", "Monday",   "Tuesday", "Wednesday", "Thursday",
-      "Friday", "Saturday", "Sun",     "Mon",       "Tue",
-      "Wed",    "Thu",      "Fri",     "Sat"};
-  return std::make_pair(nm, nm + sizeof(nm) / sizeof(nm[0]));
+inline
+std::pair<const std::string*, const std::string*>
+weekday_names()
+{
+    static const std::string nm[] =
+    {
+        "Sunday",
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sun",
+        "Mon",
+        "Tue",
+        "Wed",
+        "Thu",
+        "Fri",
+        "Sat"
+    };
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
-inline std::pair<const std::string*, const std::string*> month_names() {
-  static const std::string nm[] = {
-      "January", "February", "March",     "April",   "May",      "June",
-      "July",    "August",   "September", "October", "November", "December",
-      "Jan",     "Feb",      "Mar",       "Apr",     "May",      "Jun",
-      "Jul",     "Aug",      "Sep",       "Oct",     "Nov",      "Dec"};
-  return std::make_pair(nm, nm + sizeof(nm) / sizeof(nm[0]));
+inline
+std::pair<const std::string*, const std::string*>
+month_names()
+{
+    static const std::string nm[] =
+    {
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec"
+    };
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
-inline std::pair<const std::string*, const std::string*> ampm_names() {
-  static const std::string nm[] = {"AM", "PM"};
-  return std::make_pair(nm, nm + sizeof(nm) / sizeof(nm[0]));
+inline
+std::pair<const std::string*, const std::string*>
+ampm_names()
+{
+    static const std::string nm[] =
+    {
+        "AM",
+        "PM"
+    };
+    return std::make_pair(nm, nm+sizeof(nm)/sizeof(nm[0]));
 }
 
 template <class CharT, class Traits, class FwdIter>
-FwdIter scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb,
-                     FwdIter ke) {
-  size_t nkw = static_cast<size_t>(std::distance(kb, ke));
-  const unsigned char doesnt_match = '\0';
-  const unsigned char might_match = '\1';
-  const unsigned char does_match = '\2';
-  unsigned char statbuf[100];
-  unsigned char* status = statbuf;
-  std::unique_ptr<unsigned char, void (*)(void*)> stat_hold(0, free);
-  if (nkw > sizeof(statbuf)) {
-    status = (unsigned char*)std::malloc(nkw);
-    if (status == nullptr) throw std::bad_alloc();
-    stat_hold.reset(status);
-  }
-  size_t n_might_match = nkw;  // At this point, any keyword might match
-  size_t n_does_match = 0;     // but none of them definitely do
-  // Initialize all statuses to might_match, except for "" keywords are
-  // does_match
-  unsigned char* st = status;
-  for (auto ky = kb; ky != ke; ++ky, ++st) {
-    if (!ky->empty())
-      *st = might_match;
-    else {
-      *st = does_match;
-      --n_might_match;
-      ++n_does_match;
+FwdIter
+scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb, FwdIter ke)
+{
+    size_t nkw = static_cast<size_t>(std::distance(kb, ke));
+    const unsigned char doesnt_match = '\0';
+    const unsigned char might_match = '\1';
+    const unsigned char does_match = '\2';
+    unsigned char statbuf[100];
+    unsigned char* status = statbuf;
+    std::unique_ptr<unsigned char, void(*)(void*)> stat_hold(0, free);
+    if (nkw > sizeof(statbuf))
+    {
+        status = (unsigned char*)std::malloc(nkw);
+        if (status == nullptr)
+            throw std::bad_alloc();
+        stat_hold.reset(status);
     }
-  }
-  // While there might be a match, test keywords against the next CharT
-  for (size_t indx = 0; is && n_might_match > 0; ++indx) {
-    // Peek at the next CharT but don't consume it
-    auto ic = is.peek();
-    if (ic == EOF) {
-      is.setstate(std::ios::eofbit);
-      break;
-    }
-    auto c = static_cast<char>(toupper(static_cast<unsigned char>(ic)));
-    bool consume = false;
-    // For each keyword which might match, see if the indx character is c
-    // If a match if found, consume c
-    // If a match is found, and that is the last character in the keyword,
-    //    then that keyword matches.
-    // If the keyword doesn't match this character, then change the keyword
-    //    to doesn't match
-    st = status;
-    for (auto ky = kb; ky != ke; ++ky, ++st) {
-      if (*st == might_match) {
-        if (c == static_cast<char>(
-                     toupper(static_cast<unsigned char>((*ky)[indx])))) {
-          consume = true;
-          if (ky->size() == indx + 1) {
+    size_t n_might_match = nkw;  // At this point, any keyword might match
+    size_t n_does_match = 0;     // but none of them definitely do
+    // Initialize all statuses to might_match, except for "" keywords are does_match
+    unsigned char* st = status;
+    for (auto ky = kb; ky != ke; ++ky, ++st)
+    {
+        if (!ky->empty())
+            *st = might_match;
+        else
+        {
             *st = does_match;
             --n_might_match;
             ++n_does_match;
-          }
-        } else {
-          *st = doesnt_match;
-          --n_might_match;
         }
-      }
     }
-    // consume if we matched a character
-    if (consume) {
-      (void)is.get();
-      // If we consumed a character and there might be a matched keyword that
-      //   was marked matched on a previous iteration, then such keywords
-      //   are now marked as not matching.
-      if (n_might_match + n_does_match > 1) {
+    // While there might be a match, test keywords against the next CharT
+    for (size_t indx = 0; is && n_might_match > 0; ++indx)
+    {
+        // Peek at the next CharT but don't consume it
+        auto ic = is.peek();
+        if (ic == EOF)
+        {
+            is.setstate(std::ios::eofbit);
+            break;
+        }
+        auto c = static_cast<char>(toupper(static_cast<unsigned char>(ic)));
+        bool consume = false;
+        // For each keyword which might match, see if the indx character is c
+        // If a match if found, consume c
+        // If a match is found, and that is the last character in the keyword,
+        //    then that keyword matches.
+        // If the keyword doesn't match this character, then change the keyword
+        //    to doesn't match
         st = status;
-        for (auto ky = kb; ky != ke; ++ky, ++st) {
-          if (*st == does_match && ky->size() != indx + 1) {
-            *st = doesnt_match;
-            --n_does_match;
-          }
+        for (auto ky = kb; ky != ke; ++ky, ++st)
+        {
+            if (*st == might_match)
+            {
+                if (c == static_cast<char>(toupper(static_cast<unsigned char>((*ky)[indx]))))
+                {
+                    consume = true;
+                    if (ky->size() == indx+1)
+                    {
+                        *st = does_match;
+                        --n_might_match;
+                        ++n_does_match;
+                    }
+                }
+                else
+                {
+                    *st = doesnt_match;
+                    --n_might_match;
+                }
+            }
         }
-      }
+        // consume if we matched a character
+        if (consume)
+        {
+            (void)is.get();
+            // If we consumed a character and there might be a matched keyword that
+            //   was marked matched on a previous iteration, then such keywords
+            //   are now marked as not matching.
+            if (n_might_match + n_does_match > 1)
+            {
+                st = status;
+                for (auto ky = kb; ky != ke; ++ky, ++st)
+                {
+                    if (*st == does_match && ky->size() != indx+1)
+                    {
+                        *st = doesnt_match;
+                        --n_does_match;
+                    }
+                }
+            }
+        }
     }
-  }
-  // We've exited the loop because we hit eof and/or we have no more "might
-  // matches". Return the first matching result
-  for (st = status; kb != ke; ++kb, ++st)
-    if (*st == does_match) break;
-  if (kb == ke) is.setstate(std::ios::failbit);
-  return kb;
+    // We've exited the loop because we hit eof and/or we have no more "might matches".
+    // Return the first matching result
+    for (st = status; kb != ke; ++kb, ++st)
+        if (*st == does_match)
+            break;
+    if (kb == ke)
+        is.setstate(std::ios::failbit);
+    return kb;
 }
 
 }  // namespace detail
@@ -4023,2688 +5039,3211 @@ FwdIter scan_keyword(std::basic_istream<CharT, Traits>& is, FwdIter kb,
 #endif  // ONLY_C_LOCALE
 
 template <class CharT, class Traits, class Duration>
-std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const fields<Duration>& fds, const std::string* abbrev,
-    const std::chrono::seconds* offset_sec) {
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const fields<Duration>& fds, const std::string* abbrev,
+          const std::chrono::seconds* offset_sec)
+{
 #if ONLY_C_LOCALE
-  using detail::ampm_names;
-  using detail::month_names;
-  using detail::weekday_names;
+    using detail::weekday_names;
+    using detail::month_names;
+    using detail::ampm_names;
 #endif
-  using detail::extract_month;
-  using detail::extract_weekday;
-  using detail::get_units;
-  using detail::save_ostream;
-  using std::ios;
-  using std::chrono::duration_cast;
-  using std::chrono::hours;
-  using std::chrono::minutes;
-  using std::chrono::seconds;
-  date::detail::save_ostream<CharT, Traits> ss(os);
-  os.fill(' ');
-  os.flags(std::ios::skipws | std::ios::dec);
-  os.width(0);
-  tm tm{};
-  bool insert_negative =
-      fds.has_tod && fds.tod.to_duration() < Duration::zero();
+    using detail::save_ostream;
+    using detail::get_units;
+    using detail::extract_weekday;
+    using detail::extract_month;
+    using std::ios;
+    using std::chrono::duration_cast;
+    using std::chrono::seconds;
+    using std::chrono::minutes;
+    using std::chrono::hours;
+    date::detail::save_ostream<CharT, Traits> ss(os);
+    os.fill(' ');
+    os.flags(std::ios::skipws | std::ios::dec);
+    os.width(0);
+    tm tm{};
+    bool insert_negative = fds.has_tod && fds.tod.to_duration() < Duration::zero();
 #if !ONLY_C_LOCALE
-  auto& facet = std::use_facet<std::time_put<CharT>>(os.getloc());
+    auto& facet = std::use_facet<std::time_put<CharT>>(os.getloc());
 #endif
-  const CharT* command = nullptr;
-  CharT modified = CharT{};
-  for (; *fmt; ++fmt) {
-    switch (*fmt) {
-      case 'a':
-      case 'A':
-        if (command) {
-          if (modified == CharT{}) {
-            tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
-            if (os.fail()) return os;
+    const CharT* command = nullptr;
+    CharT modified = CharT{};
+    for (; *fmt; ++fmt)
+    {
+        switch (*fmt)
+        {
+        case 'a':
+        case 'A':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
+                    if (os.fail())
+                        return os;
 #if !ONLY_C_LOCALE
-            const CharT f[] = {'%', *fmt};
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-#else   // ONLY_C_LOCALE
-            os << weekday_names().first[tm.tm_wday + 7 * (*fmt == 'a')];
+                    const CharT f[] = {'%', *fmt};
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+#else  // ONLY_C_LOCALE
+                    os << weekday_names().first[tm.tm_wday+7*(*fmt == 'a')];
 #endif  // ONLY_C_LOCALE
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'b':
-      case 'B':
-      case 'h':
-        if (command) {
-          if (modified == CharT{}) {
-            tm.tm_mon = static_cast<int>(extract_month(os, fds)) - 1;
-#if !ONLY_C_LOCALE
-            const CharT f[] = {'%', *fmt};
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-#else   // ONLY_C_LOCALE
-            os << month_names().first[tm.tm_mon + 12 * (*fmt != 'B')];
-#endif  // ONLY_C_LOCALE
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'c':
-      case 'x':
-        if (command) {
-          if (modified == CharT{'O'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.ok()) os.setstate(std::ios::failbit);
-            if (*fmt == 'c' && !fds.has_tod) os.setstate(std::ios::failbit);
-#if !ONLY_C_LOCALE
-            tm = std::tm{};
-            auto const& ymd = fds.ymd;
-            auto ld = local_days(ymd);
-            if (*fmt == 'c') {
-              tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
-              tm.tm_min = static_cast<int>(fds.tod.minutes().count());
-              tm.tm_hour = static_cast<int>(fds.tod.hours().count());
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
             }
-            tm.tm_mday = static_cast<int>(static_cast<unsigned>(ymd.day()));
-            tm.tm_mon = static_cast<int>(extract_month(os, fds) - 1);
-            tm.tm_year = static_cast<int>(ymd.year()) - 1900;
-            tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
-            if (os.fail()) return os;
-            tm.tm_yday =
-                static_cast<int>((ld - local_days(ymd.year() / 1 / 1)).count());
-            CharT f[3] = {'%'};
-            auto fe = std::begin(f) + 1;
-            if (modified == CharT{'E'}) *fe++ = modified;
-            *fe++ = *fmt;
-            facet.put(os, os, os.fill(), &tm, std::begin(f), fe);
-#else   // ONLY_C_LOCALE
-            if (*fmt == 'c') {
-              auto wd = static_cast<int>(extract_weekday(os, fds));
-              os << weekday_names().first[static_cast<unsigned>(wd) + 7] << ' ';
-              os << month_names().first[extract_month(os, fds) - 1 + 12] << ' ';
-              auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
-              if (d < 10) os << ' ';
-              os << d << ' '
-                 << make_time(duration_cast<seconds>(fds.tod.to_duration()))
-                 << ' ' << fds.ymd.year();
+            else
+                os << *fmt;
+            break;
+        case 'b':
+        case 'B':
+        case 'h':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    tm.tm_mon = static_cast<int>(extract_month(os, fds)) - 1;
+#if !ONLY_C_LOCALE
+                    const CharT f[] = {'%', *fmt};
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+#else  // ONLY_C_LOCALE
+                    os << month_names().first[tm.tm_mon+12*(*fmt != 'B')];
+#endif  // ONLY_C_LOCALE
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'c':
+        case 'x':
+            if (command)
+            {
+                if (modified == CharT{'O'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    if (*fmt == 'c' && !fds.has_tod)
+                        os.setstate(std::ios::failbit);
+#if !ONLY_C_LOCALE
+                    tm = std::tm{};
+                    auto const& ymd = fds.ymd;
+                    auto ld = local_days(ymd);
+                    if (*fmt == 'c')
+                    {
+                        tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
+                        tm.tm_min = static_cast<int>(fds.tod.minutes().count());
+                        tm.tm_hour = static_cast<int>(fds.tod.hours().count());
+                    }
+                    tm.tm_mday = static_cast<int>(static_cast<unsigned>(ymd.day()));
+                    tm.tm_mon = static_cast<int>(extract_month(os, fds) - 1);
+                    tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                    tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
+                    if (os.fail())
+                        return os;
+                    tm.tm_yday = static_cast<int>((ld - local_days(ymd.year()/1/1)).count());
+                    CharT f[3] = {'%'};
+                    auto fe = std::begin(f) + 1;
+                    if (modified == CharT{'E'})
+                        *fe++ = modified;
+                    *fe++ = *fmt;
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), fe);
+#else  // ONLY_C_LOCALE
+                    if (*fmt == 'c')
+                    {
+                        auto wd = static_cast<int>(extract_weekday(os, fds));
+                        os << weekday_names().first[static_cast<unsigned>(wd)+7]
+                           << ' ';
+                        os << month_names().first[extract_month(os, fds)-1+12] << ' ';
+                        auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
+                        if (d < 10)
+                            os << ' ';
+                        os << d << ' '
+                           << make_time(duration_cast<seconds>(fds.tod.to_duration()))
+                           << ' ' << fds.ymd.year();
 
-            } else  // *fmt == 'x'
-            {
-              auto const& ymd = fds.ymd;
-              save_ostream<CharT, Traits> _(os);
-              os.fill('0');
-              os.flags(std::ios::dec | std::ios::right);
-              os.width(2);
-              os << static_cast<unsigned>(ymd.month()) << CharT{'/'};
-              os.width(2);
-              os << static_cast<unsigned>(ymd.day()) << CharT{'/'};
-              os.width(2);
-              os << static_cast<int>(ymd.year()) % 100;
-            }
+                    }
+                    else  // *fmt == 'x'
+                    {
+                        auto const& ymd = fds.ymd;
+                        save_ostream<CharT, Traits> _(os);
+                        os.fill('0');
+                        os.flags(std::ios::dec | std::ios::right);
+                        os.width(2);
+                        os << static_cast<unsigned>(ymd.month()) << CharT{'/'};
+                        os.width(2);
+                        os << static_cast<unsigned>(ymd.day()) << CharT{'/'};
+                        os.width(2);
+                        os << static_cast<int>(ymd.year()) % 100;
+                    }
 #endif  // ONLY_C_LOCALE
-          }
-          command = nullptr;
-          modified = CharT{};
-        } else
-          os << *fmt;
-        break;
-      case 'C':
-        if (command) {
-          if (modified == CharT{'O'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.year().ok()) os.setstate(std::ios::failbit);
-            auto y = static_cast<int>(fds.ymd.year());
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              save_ostream<CharT, Traits> _(os);
-              os.fill('0');
-              os.flags(std::ios::dec | std::ios::right);
-              if (y >= 0) {
-                os.width(2);
-                os << y / 100;
-              } else {
-                os << CharT{'-'};
-                os.width(2);
-                os << -(y - 99) / 100;
-              }
+                }
+                command = nullptr;
+                modified = CharT{};
             }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'E'}) {
-              tm.tm_year = y - 1900;
-              CharT f[3] = {'%', 'E', 'C'};
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          command = nullptr;
-          modified = CharT{};
-        } else
-          os << *fmt;
-        break;
-      case 'd':
-      case 'e':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.day().ok()) os.setstate(std::ios::failbit);
-            auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              save_ostream<CharT, Traits> _(os);
-              if (*fmt == CharT{'d'})
-                os.fill('0');
-              else
-                os.fill(' ');
-              os.flags(std::ios::dec | std::ios::right);
-              os.width(2);
-              os << d;
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              tm.tm_mday = d;
-              CharT f[3] = {'%', 'O', *fmt};
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          command = nullptr;
-          modified = CharT{};
-        } else
-          os << *fmt;
-        break;
-      case 'D':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.ymd.ok()) os.setstate(std::ios::failbit);
-            auto const& ymd = fds.ymd;
-            save_ostream<CharT, Traits> _(os);
-            os.fill('0');
-            os.flags(std::ios::dec | std::ios::right);
-            os.width(2);
-            os << static_cast<unsigned>(ymd.month()) << CharT{'/'};
-            os.width(2);
-            os << static_cast<unsigned>(ymd.day()) << CharT{'/'};
-            os.width(2);
-            os << static_cast<int>(ymd.year()) % 100;
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'F':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.ymd.ok()) os.setstate(std::ios::failbit);
-            auto const& ymd = fds.ymd;
-            save_ostream<CharT, Traits> _(os);
-            os.imbue(std::locale::classic());
-            os.fill('0');
-            os.flags(std::ios::dec | std::ios::right);
-            os.width(4);
-            os << static_cast<int>(ymd.year()) << CharT{'-'};
-            os.width(2);
-            os << static_cast<unsigned>(ymd.month()) << CharT{'-'};
-            os.width(2);
-            os << static_cast<unsigned>(ymd.day());
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'g':
-      case 'G':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.ymd.ok()) os.setstate(std::ios::failbit);
-            auto ld = local_days(fds.ymd);
-            auto y = year_month_day{ld + days{3}}.year();
-            auto start =
-                local_days((y - years{1}) / December / Thursday[last]) +
-                (Monday - Thursday);
-            if (ld < start) --y;
-            if (*fmt == CharT{'G'})
-              os << y;
-            else {
-              save_ostream<CharT, Traits> _(os);
-              os.fill('0');
-              os.flags(std::ios::dec | std::ios::right);
-              os.width(2);
-              os << std::abs(static_cast<int>(y)) % 100;
-            }
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'H':
-      case 'I':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            if (insert_negative) {
-              os << '-';
-              insert_negative = false;
-            }
-            auto hms = fds.tod;
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              auto h =
-                  *fmt == CharT{'I'} ? date::make12(hms.hours()) : hms.hours();
-              if (h < hours{10}) os << CharT{'0'};
-              os << h.count();
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_hour = static_cast<int>(hms.hours().count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'j':
-        if (command) {
-          if (modified == CharT{}) {
-            if (fds.ymd.ok() || fds.has_tod) {
-              days doy;
-              if (fds.ymd.ok()) {
-                auto ld = local_days(fds.ymd);
-                auto y = fds.ymd.year();
-                doy = ld - local_days(y / January / 1) + days{1};
-              } else {
-                doy = duration_cast<days>(fds.tod.to_duration());
-              }
-              save_ostream<CharT, Traits> _(os);
-              os.fill('0');
-              os.flags(std::ios::dec | std::ios::right);
-              os.width(3);
-              os << doy.count();
-            } else {
-              os.setstate(std::ios::failbit);
-            }
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'm':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.month().ok()) os.setstate(std::ios::failbit);
-            auto m = static_cast<unsigned>(fds.ymd.month());
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              if (m < 10) os << CharT{'0'};
-              os << m;
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_mon = static_cast<int>(m - 1);
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'M':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            if (insert_negative) {
-              os << '-';
-              insert_negative = false;
-            }
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              if (fds.tod.minutes() < minutes{10}) os << CharT{'0'};
-              os << fds.tod.minutes().count();
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_min = static_cast<int>(fds.tod.minutes().count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'n':
-        if (command) {
-          if (modified == CharT{})
-            os << CharT{'\n'};
-          else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'p':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-#if !ONLY_C_LOCALE
-            const CharT f[] = {'%', *fmt};
-            tm.tm_hour = static_cast<int>(fds.tod.hours().count());
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-#else
-            if (date::is_am(fds.tod.hours()))
-              os << ampm_names().first[0];
             else
-              os << ampm_names().first[1];
+                os << *fmt;
+            break;
+        case 'C':
+            if (command)
+            {
+                if (modified == CharT{'O'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.year().ok())
+                        os.setstate(std::ios::failbit);
+                    auto y = static_cast<int>(fds.ymd.year());
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
 #endif
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'Q':
-      case 'q':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            auto d = fds.tod.to_duration();
-            if (*fmt == 'q')
-              os << get_units<CharT>(typename decltype(d)::period::type{});
+                    {
+                        save_ostream<CharT, Traits> _(os);
+                        os.fill('0');
+                        os.flags(std::ios::dec | std::ios::right);
+                        if (y >= 0)
+                        {
+                            os.width(2);
+                            os << y/100;
+                        }
+                        else
+                        {
+                            os << CharT{'-'};
+                            os.width(2);
+                            os << -(y-99)/100;
+                        }
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'E'})
+                    {
+                        tm.tm_year = y - 1900;
+                        CharT f[3] = {'%', 'E', 'C'};
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                command = nullptr;
+                modified = CharT{};
+            }
             else
-              os << d.count();
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'r':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
+                os << *fmt;
+            break;
+        case 'd':
+        case 'e':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.day().ok())
+                        os.setstate(std::ios::failbit);
+                    auto d = static_cast<int>(static_cast<unsigned>(fds.ymd.day()));
 #if !ONLY_C_LOCALE
-            const CharT f[] = {'%', *fmt};
-            tm.tm_hour = static_cast<int>(fds.tod.hours().count());
-            tm.tm_min = static_cast<int>(fds.tod.minutes().count());
-            tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-#else
-            hh_mm_ss<seconds> tod(
-                duration_cast<seconds>(fds.tod.to_duration()));
-            save_ostream<CharT, Traits> _(os);
-            os.fill('0');
-            os.width(2);
-            os << date::make12(tod.hours()).count() << CharT{':'};
-            os.width(2);
-            os << tod.minutes().count() << CharT{':'};
-            os.width(2);
-            os << tod.seconds().count() << CharT{' '};
-            if (date::is_am(tod.hours()))
-              os << ampm_names().first[0];
+                    if (modified == CharT{})
+#endif
+                    {
+                        save_ostream<CharT, Traits> _(os);
+                        if (*fmt == CharT{'d'})
+                            os.fill('0');
+                        else
+                            os.fill(' ');
+                        os.flags(std::ios::dec | std::ios::right);
+                        os.width(2);
+                        os << d;
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        tm.tm_mday = d;
+                        CharT f[3] = {'%', 'O', *fmt};
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                command = nullptr;
+                modified = CharT{};
+            }
             else
-              os << ampm_names().first[1];
-#endif
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'R':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            if (fds.tod.hours() < hours{10}) os << CharT{'0'};
-            os << fds.tod.hours().count() << CharT{':'};
-            if (fds.tod.minutes() < minutes{10}) os << CharT{'0'};
-            os << fds.tod.minutes().count();
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'S':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            if (insert_negative) {
-              os << '-';
-              insert_negative = false;
-            }
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+                os << *fmt;
+            break;
+        case 'D':
+            if (command)
             {
-              os << fds.tod.s_;
+                if (modified == CharT{})
+                {
+                    if (!fds.ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto const& ymd = fds.ymd;
+                    save_ostream<CharT, Traits> _(os);
+                    os.fill('0');
+                    os.flags(std::ios::dec | std::ios::right);
+                    os.width(2);
+                    os << static_cast<unsigned>(ymd.month()) << CharT{'/'};
+                    os.width(2);
+                    os << static_cast<unsigned>(ymd.day()) << CharT{'/'};
+                    os.width(2);
+                    os << static_cast<int>(ymd.year()) % 100;
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
             }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_sec = static_cast<int>(fds.tod.s_.seconds().count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 't':
-        if (command) {
-          if (modified == CharT{})
-            os << CharT{'\t'};
-          else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'T':
-        if (command) {
-          if (modified == CharT{}) {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-            os << fds.tod;
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'u':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            auto wd = extract_weekday(os, fds);
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+            else
+                os << *fmt;
+            break;
+        case 'F':
+            if (command)
             {
-              os << (wd != 0 ? wd : 7u);
+                if (modified == CharT{})
+                {
+                    if (!fds.ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto const& ymd = fds.ymd;
+                    save_ostream<CharT, Traits> _(os);
+                    os.imbue(std::locale::classic());
+                    os.fill('0');
+                    os.flags(std::ios::dec | std::ios::right);
+                    os.width(4);
+                    os << static_cast<int>(ymd.year()) << CharT{'-'};
+                    os.width(2);
+                    os << static_cast<unsigned>(ymd.month()) << CharT{'-'};
+                    os.width(2);
+                    os << static_cast<unsigned>(ymd.day());
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
             }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_wday = static_cast<int>(wd);
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'U':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            auto const& ymd = fds.ymd;
-            if (!ymd.ok()) os.setstate(std::ios::failbit);
-            auto ld = local_days(ymd);
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+            else
+                os << *fmt;
+            break;
+        case 'g':
+        case 'G':
+            if (command)
             {
-              auto st = local_days(Sunday[1] / January / ymd.year());
-              if (ld < st)
-                os << CharT{'0'} << CharT{'0'};
-              else {
-                auto wn = duration_cast<weeks>(ld - st).count() + 1;
-                if (wn < 10) os << CharT{'0'};
-                os << wn;
-              }
+                if (modified == CharT{})
+                {
+                    if (!fds.ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto ld = local_days(fds.ymd);
+                    auto y = year_month_day{ld + days{3}}.year();
+                    auto start = local_days((y-years{1})/December/Thursday[last]) +
+                                 (Monday-Thursday);
+                    if (ld < start)
+                        --y;
+                    if (*fmt == CharT{'G'})
+                        os << y;
+                    else
+                    {
+                        save_ostream<CharT, Traits> _(os);
+                        os.fill('0');
+                        os.flags(std::ios::dec | std::ios::right);
+                        os.width(2);
+                        os << std::abs(static_cast<int>(y)) % 100;
+                    }
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
             }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_year = static_cast<int>(ymd.year()) - 1900;
-              tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
-              if (os.fail()) return os;
-              tm.tm_yday = static_cast<int>(
-                  (ld - local_days(ymd.year() / 1 / 1)).count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'V':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.ok()) os.setstate(std::ios::failbit);
-            auto ld = local_days(fds.ymd);
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+            else
+                os << *fmt;
+            break;
+        case 'H':
+        case 'I':
+            if (command)
             {
-              auto y = year_month_day{ld + days{3}}.year();
-              auto st = local_days((y - years{1}) / 12 / Thursday[last]) +
-                        (Monday - Thursday);
-              if (ld < st) {
-                --y;
-                st = local_days((y - years{1}) / 12 / Thursday[last]) +
-                     (Monday - Thursday);
-              }
-              auto wn = duration_cast<weeks>(ld - st).count() + 1;
-              if (wn < 10) os << CharT{'0'};
-              os << wn;
-            }
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    if (insert_negative)
+                    {
+                        os << '-';
+                        insert_negative = false;
+                    }
+                    auto hms = fds.tod;
 #if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              auto const& ymd = fds.ymd;
-              tm.tm_year = static_cast<int>(ymd.year()) - 1900;
-              tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
-              if (os.fail()) return os;
-              tm.tm_yday = static_cast<int>(
-                  (ld - local_days(ymd.year() / 1 / 1)).count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
+                    if (modified == CharT{})
 #endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'w':
-        if (command) {
-          auto wd = extract_weekday(os, fds);
-          if (os.fail()) return os;
+                    {
+                        auto h = *fmt == CharT{'I'} ? date::make12(hms.hours()) : hms.hours();
+                        if (h < hours{10})
+                            os << CharT{'0'};
+                        os << h.count();
+                    }
 #if !ONLY_C_LOCALE
-          if (modified == CharT{})
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_hour = static_cast<int>(hms.hours().count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'j':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    if (fds.ymd.ok() || fds.has_tod)
+                    {
+                        days doy;
+                        if (fds.ymd.ok())
+                        {
+                            auto ld = local_days(fds.ymd);
+                            auto y = fds.ymd.year();
+                            doy = ld - local_days(y/January/1) + days{1};
+                        }
+                        else
+                        {
+                            doy = duration_cast<days>(fds.tod.to_duration());
+                        }
+                        save_ostream<CharT, Traits> _(os);
+                        os.fill('0');
+                        os.flags(std::ios::dec | std::ios::right);
+                        os.width(3);
+                        os << doy.count();
+                    }
+                    else
+                    {
+                        os.setstate(std::ios::failbit);
+                    }
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'm':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.month().ok())
+                        os.setstate(std::ios::failbit);
+                    auto m = static_cast<unsigned>(fds.ymd.month());
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        if (m < 10)
+                            os << CharT{'0'};
+                        os << m;
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_mon = static_cast<int>(m-1);
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'M':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    if (insert_negative)
+                    {
+                        os << '-';
+                        insert_negative = false;
+                    }
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        if (fds.tod.minutes() < minutes{10})
+                            os << CharT{'0'};
+                        os << fds.tod.minutes().count();
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_min = static_cast<int>(fds.tod.minutes().count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'n':
+            if (command)
+            {
+                if (modified == CharT{})
+                    os << CharT{'\n'};
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'p':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+#if !ONLY_C_LOCALE
+                    const CharT f[] = {'%', *fmt};
+                    tm.tm_hour = static_cast<int>(fds.tod.hours().count());
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
 #else
-          if (modified != CharT{'E'})
+                    if (date::is_am(fds.tod.hours()))
+                        os << ampm_names().first[0];
+                    else
+                        os << ampm_names().first[1];
 #endif
-          {
-            os << wd;
-          }
-#if !ONLY_C_LOCALE
-          else if (modified == CharT{'O'}) {
-            const CharT f[] = {'%', modified, *fmt};
-            tm.tm_wday = static_cast<int>(wd);
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-          }
-#endif
-          else {
-            os << CharT{'%'} << modified << *fmt;
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'W':
-        if (command) {
-          if (modified == CharT{'E'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            auto const& ymd = fds.ymd;
-            if (!ymd.ok()) os.setstate(std::ios::failbit);
-            auto ld = local_days(ymd);
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'Q':
+        case 'q':
+            if (command)
             {
-              auto st = local_days(Monday[1] / January / ymd.year());
-              if (ld < st)
-                os << CharT{'0'} << CharT{'0'};
-              else {
-                auto wn = duration_cast<weeks>(ld - st).count() + 1;
-                if (wn < 10) os << CharT{'0'};
-                os << wn;
-              }
+                if (modified == CharT{})
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    auto d = fds.tod.to_duration();
+                    if (*fmt == 'q')
+                        os << get_units<CharT>(typename decltype(d)::period::type{});
+                    else
+                        os << d.count();
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                }
+                modified = CharT{};
+                command = nullptr;
             }
+            else
+                os << *fmt;
+            break;
+        case 'r':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
 #if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_year = static_cast<int>(ymd.year()) - 1900;
-              tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
-              if (os.fail()) return os;
-              tm.tm_yday = static_cast<int>(
-                  (ld - local_days(ymd.year() / 1 / 1)).count());
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
-#endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'X':
-        if (command) {
-          if (modified == CharT{'O'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.has_tod) os.setstate(std::ios::failbit);
-#if !ONLY_C_LOCALE
-            tm = std::tm{};
-            tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
-            tm.tm_min = static_cast<int>(fds.tod.minutes().count());
-            tm.tm_hour = static_cast<int>(fds.tod.hours().count());
-            CharT f[3] = {'%'};
-            auto fe = std::begin(f) + 1;
-            if (modified == CharT{'E'}) *fe++ = modified;
-            *fe++ = *fmt;
-            facet.put(os, os, os.fill(), &tm, std::begin(f), fe);
+                    const CharT f[] = {'%', *fmt};
+                    tm.tm_hour = static_cast<int>(fds.tod.hours().count());
+                    tm.tm_min = static_cast<int>(fds.tod.minutes().count());
+                    tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
 #else
-            os << fds.tod;
+                    hh_mm_ss<seconds> tod(duration_cast<seconds>(fds.tod.to_duration()));
+                    save_ostream<CharT, Traits> _(os);
+                    os.fill('0');
+                    os.width(2);
+                    os << date::make12(tod.hours()).count() << CharT{':'};
+                    os.width(2);
+                    os << tod.minutes().count() << CharT{':'};
+                    os.width(2);
+                    os << tod.seconds().count() << CharT{' '};
+                    if (date::is_am(tod.hours()))
+                        os << ampm_names().first[0];
+                    else
+                        os << ampm_names().first[1];
 #endif
-          }
-          command = nullptr;
-          modified = CharT{};
-        } else
-          os << *fmt;
-        break;
-      case 'y':
-        if (command) {
-          if (!fds.ymd.year().ok()) os.setstate(std::ios::failbit);
-          auto y = static_cast<int>(fds.ymd.year());
-#if !ONLY_C_LOCALE
-          if (modified == CharT{}) {
-#endif
-            y = std::abs(y) % 100;
-            if (y < 10) os << CharT{'0'};
-            os << y;
-#if !ONLY_C_LOCALE
-          } else {
-            const CharT f[] = {'%', modified, *fmt};
-            tm.tm_year = y - 1900;
-            facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-          }
-#endif
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'Y':
-        if (command) {
-          if (modified == CharT{'O'})
-            os << CharT{'%'} << modified << *fmt;
-          else {
-            if (!fds.ymd.year().ok()) os.setstate(std::ios::failbit);
-            auto y = fds.ymd.year();
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'R':
+            if (command)
             {
-              save_ostream<CharT, Traits> _(os);
-              os.imbue(std::locale::classic());
-              os << y;
+                if (modified == CharT{})
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    if (fds.tod.hours() < hours{10})
+                        os << CharT{'0'};
+                    os << fds.tod.hours().count() << CharT{':'};
+                    if (fds.tod.minutes() < minutes{10})
+                        os << CharT{'0'};
+                    os << fds.tod.minutes().count();
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
             }
+            else
+                os << *fmt;
+            break;
+        case 'S':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    if (insert_negative)
+                    {
+                        os << '-';
+                        insert_negative = false;
+                    }
 #if !ONLY_C_LOCALE
-            else if (modified == CharT{'E'}) {
-              const CharT f[] = {'%', modified, *fmt};
-              tm.tm_year = static_cast<int>(y) - 1900;
-              facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
-            }
+                    if (modified == CharT{})
 #endif
-          }
-          modified = CharT{};
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'z':
-        if (command) {
-          if (offset_sec == nullptr) {
-            // Can not format %z with unknown offset
-            os.setstate(ios::failbit);
-            return os;
-          }
-          auto m = duration_cast<minutes>(*offset_sec);
-          auto neg = m < minutes{0};
-          m = date::abs(m);
-          auto h = duration_cast<hours>(m);
-          m -= h;
-          if (neg)
-            os << CharT{'-'};
-          else
-            os << CharT{'+'};
-          if (h < hours{10}) os << CharT{'0'};
-          os << h.count();
-          if (modified != CharT{}) os << CharT{':'};
-          if (m < minutes{10}) os << CharT{'0'};
-          os << m.count();
-          command = nullptr;
-          modified = CharT{};
-        } else
-          os << *fmt;
-        break;
-      case 'Z':
-        if (command) {
-          if (modified == CharT{}) {
-            if (abbrev == nullptr) {
-              // Can not format %Z with unknown time_zone
-              os.setstate(ios::failbit);
-              return os;
+                    {
+                        os << fds.tod.s_;
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_sec = static_cast<int>(fds.tod.s_.seconds().count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
             }
-            for (auto c : *abbrev) os << CharT(c);
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            modified = CharT{};
-          }
-          command = nullptr;
-        } else
-          os << *fmt;
-        break;
-      case 'E':
-      case 'O':
-        if (command) {
-          if (modified == CharT{}) {
-            modified = *fmt;
-          } else {
-            os << CharT{'%'} << modified << *fmt;
-            command = nullptr;
-            modified = CharT{};
-          }
-        } else
-          os << *fmt;
-        break;
-      case '%':
-        if (command) {
-          if (modified == CharT{}) {
-            os << CharT{'%'};
-            command = nullptr;
-          } else {
-            os << CharT{'%'} << modified << CharT{'%'};
-            command = nullptr;
-            modified = CharT{};
-          }
-        } else
-          command = fmt;
-        break;
-      default:
-        if (command) {
-          os << CharT{'%'};
-          command = nullptr;
+            else
+                os << *fmt;
+            break;
+        case 't':
+            if (command)
+            {
+                if (modified == CharT{})
+                    os << CharT{'\t'};
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'T':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+                    os << fds.tod;
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'u':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    auto wd = extract_weekday(os, fds);
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        os << (wd != 0 ? wd : 7u);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_wday = static_cast<int>(wd);
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'U':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    auto const& ymd = fds.ymd;
+                    if (!ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto ld = local_days(ymd);
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        auto st = local_days(Sunday[1]/January/ymd.year());
+                        if (ld < st)
+                            os << CharT{'0'} << CharT{'0'};
+                        else
+                        {
+                            auto wn = duration_cast<weeks>(ld - st).count() + 1;
+                            if (wn < 10)
+                                os << CharT{'0'};
+                            os << wn;
+                        }
+                   }
+ #if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
+                        if (os.fail())
+                            return os;
+                        tm.tm_yday = static_cast<int>((ld - local_days(ymd.year()/1/1)).count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'V':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto ld = local_days(fds.ymd);
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        auto y = year_month_day{ld + days{3}}.year();
+                        auto st = local_days((y-years{1})/12/Thursday[last]) +
+                                  (Monday-Thursday);
+                        if (ld < st)
+                        {
+                            --y;
+                            st = local_days((y - years{1})/12/Thursday[last]) +
+                                 (Monday-Thursday);
+                        }
+                        auto wn = duration_cast<weeks>(ld - st).count() + 1;
+                        if (wn < 10)
+                            os << CharT{'0'};
+                        os << wn;
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        auto const& ymd = fds.ymd;
+                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
+                        if (os.fail())
+                            return os;
+                        tm.tm_yday = static_cast<int>((ld - local_days(ymd.year()/1/1)).count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'w':
+            if (command)
+            {
+                auto wd = extract_weekday(os, fds);
+                if (os.fail())
+                    return os;
+#if !ONLY_C_LOCALE
+                if (modified == CharT{})
+#else
+                if (modified != CharT{'E'})
+#endif
+                {
+                    os << wd;
+                }
+#if !ONLY_C_LOCALE
+                else if (modified == CharT{'O'})
+                {
+                    const CharT f[] = {'%', modified, *fmt};
+                    tm.tm_wday = static_cast<int>(wd);
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                }
+#endif
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'W':
+            if (command)
+            {
+                if (modified == CharT{'E'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    auto const& ymd = fds.ymd;
+                    if (!ymd.ok())
+                        os.setstate(std::ios::failbit);
+                    auto ld = local_days(ymd);
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        auto st = local_days(Monday[1]/January/ymd.year());
+                        if (ld < st)
+                            os << CharT{'0'} << CharT{'0'};
+                        else
+                        {
+                            auto wn = duration_cast<weeks>(ld - st).count() + 1;
+                            if (wn < 10)
+                                os << CharT{'0'};
+                            os << wn;
+                        }
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
+                        if (os.fail())
+                            return os;
+                        tm.tm_yday = static_cast<int>((ld - local_days(ymd.year()/1/1)).count());
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'X':
+            if (command)
+            {
+                if (modified == CharT{'O'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.has_tod)
+                        os.setstate(std::ios::failbit);
+#if !ONLY_C_LOCALE
+                    tm = std::tm{};
+                    tm.tm_sec = static_cast<int>(fds.tod.seconds().count());
+                    tm.tm_min = static_cast<int>(fds.tod.minutes().count());
+                    tm.tm_hour = static_cast<int>(fds.tod.hours().count());
+                    CharT f[3] = {'%'};
+                    auto fe = std::begin(f) + 1;
+                    if (modified == CharT{'E'})
+                        *fe++ = modified;
+                    *fe++ = *fmt;
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), fe);
+#else
+                    os << fds.tod;
+#endif
+                }
+                command = nullptr;
+                modified = CharT{};
+            }
+            else
+                os << *fmt;
+            break;
+        case 'y':
+            if (command)
+            {
+                if (!fds.ymd.year().ok())
+                    os.setstate(std::ios::failbit);
+                auto y = static_cast<int>(fds.ymd.year());
+#if !ONLY_C_LOCALE
+                if (modified == CharT{})
+                {
+#endif
+                    y = std::abs(y) % 100;
+                    if (y < 10)
+                        os << CharT{'0'};
+                    os << y;
+#if !ONLY_C_LOCALE
+                }
+                else
+                {
+                    const CharT f[] = {'%', modified, *fmt};
+                    tm.tm_year = y - 1900;
+                    facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                }
+#endif
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'Y':
+            if (command)
+            {
+                if (modified == CharT{'O'})
+                    os << CharT{'%'} << modified << *fmt;
+                else
+                {
+                    if (!fds.ymd.year().ok())
+                        os.setstate(std::ios::failbit);
+                    auto y = fds.ymd.year();
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        save_ostream<CharT, Traits> _(os);
+                        os.imbue(std::locale::classic());
+                        os << y;
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'E'})
+                    {
+                        const CharT f[] = {'%', modified, *fmt};
+                        tm.tm_year = static_cast<int>(y) - 1900;
+                        facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
+                    }
+#endif
+                }
+                modified = CharT{};
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'z':
+            if (command)
+            {
+                if (offset_sec == nullptr)
+                {
+                    // Can not format %z with unknown offset
+                    os.setstate(ios::failbit);
+                    return os;
+                }
+                auto m = duration_cast<minutes>(*offset_sec);
+                auto neg = m < minutes{0};
+                m = date::abs(m);
+                auto h = duration_cast<hours>(m);
+                m -= h;
+                if (neg)
+                    os << CharT{'-'};
+                else
+                    os << CharT{'+'};
+                if (h < hours{10})
+                    os << CharT{'0'};
+                os << h.count();
+                if (modified != CharT{})
+                    os << CharT{':'};
+                if (m < minutes{10})
+                    os << CharT{'0'};
+                os << m.count();
+                command = nullptr;
+                modified = CharT{};
+            }
+            else
+                os << *fmt;
+            break;
+        case 'Z':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    if (abbrev == nullptr)
+                    {
+                        // Can not format %Z with unknown time_zone
+                        os.setstate(ios::failbit);
+                        return os;
+                    }
+                    for (auto c : *abbrev)
+                        os << CharT(c);
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    modified = CharT{};
+                }
+                command = nullptr;
+            }
+            else
+                os << *fmt;
+            break;
+        case 'E':
+        case 'O':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    modified = *fmt;
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << *fmt;
+                    command = nullptr;
+                    modified = CharT{};
+                }
+            }
+            else
+                os << *fmt;
+            break;
+        case '%':
+            if (command)
+            {
+                if (modified == CharT{})
+                {
+                    os << CharT{'%'};
+                    command = nullptr;
+                }
+                else
+                {
+                    os << CharT{'%'} << modified << CharT{'%'};
+                    command = nullptr;
+                    modified = CharT{};
+                }
+            }
+            else
+                command = fmt;
+            break;
+        default:
+            if (command)
+            {
+                os << CharT{'%'};
+                command = nullptr;
+            }
+            if (modified != CharT{})
+            {
+                os << modified;
+                modified = CharT{};
+            }
+            os << *fmt;
+            break;
         }
-        if (modified != CharT{}) {
-          os << modified;
-          modified = CharT{};
-        }
-        os << *fmt;
-        break;
     }
-  }
-  if (command) os << CharT{'%'};
-  if (modified != CharT{}) os << modified;
-  return os;
+    if (command)
+        os << CharT{'%'};
+    if (modified != CharT{})
+        os << modified;
+    return os;
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const year& y) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{y / 0 / 0};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const year& y)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{y/0/0};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const month& m) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{m / 0 / nanyear};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const month& m)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{m/0/nanyear};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const day& d) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{d / 0 / nanyear};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const day& d)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{d/0/nanyear};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const weekday& wd) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{wd};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const weekday& wd)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{wd};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const year_month& ym) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{ym / 0};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const year_month& ym)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{ym/0};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const month_day& md) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{md / nanyear};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt, const month_day& md)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{md/nanyear};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const year_month_day& ymd) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{ymd};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const year_month_day& ymd)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{ymd};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits, class Rep, class Period>
-inline std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const std::chrono::duration<Rep, Period>& d) {
-  using Duration = std::chrono::duration<Rep, Period>;
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  fields<CT> fds{hh_mm_ss<CT>{d}};
-  return to_stream(os, fmt, fds);
+inline
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const std::chrono::duration<Rep, Period>& d)
+{
+    using Duration = std::chrono::duration<Rep, Period>;
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    fields<CT> fds{hh_mm_ss<CT>{d}};
+    return to_stream(os, fmt, fds);
 }
 
 template <class CharT, class Traits, class Duration>
-std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const local_time<Duration>& tp, const std::string* abbrev = nullptr,
-    const std::chrono::seconds* offset_sec = nullptr) {
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  auto ld = std::chrono::time_point_cast<days>(tp);
-  fields<CT> fds;
-  if (ld <= tp)
-    fds = fields<CT>{year_month_day{ld}, hh_mm_ss<CT>{tp - local_seconds{ld}}};
-  else
-    fds = fields<CT>{year_month_day{ld - days{1}},
-                     hh_mm_ss<CT>{days{1} - (local_seconds{ld} - tp)}};
-  return to_stream(os, fmt, fds, abbrev, offset_sec);
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const local_time<Duration>& tp, const std::string* abbrev = nullptr,
+          const std::chrono::seconds* offset_sec = nullptr)
+{
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    auto ld = std::chrono::time_point_cast<days>(tp);
+    fields<CT> fds;
+    if (ld <= tp)
+        fds = fields<CT>{year_month_day{ld}, hh_mm_ss<CT>{tp-local_seconds{ld}}};
+    else
+        fds = fields<CT>{year_month_day{ld - days{1}},
+                         hh_mm_ss<CT>{days{1} - (local_seconds{ld} - tp)}};
+    return to_stream(os, fmt, fds, abbrev, offset_sec);
 }
 
 template <class CharT, class Traits, class Duration>
-std::basic_ostream<CharT, Traits>& to_stream(
-    std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
-    const sys_time<Duration>& tp) {
-  using std::chrono::seconds;
-  using CT = typename std::common_type<Duration, seconds>::type;
-  const std::string abbrev("UTC");
-  CONSTDATA seconds offset{0};
-  auto sd = std::chrono::time_point_cast<days>(tp);
-  fields<CT> fds;
-  if (sd <= tp)
-    fds = fields<CT>{year_month_day{sd}, hh_mm_ss<CT>{tp - sys_seconds{sd}}};
-  else
-    fds = fields<CT>{year_month_day{sd - days{1}},
-                     hh_mm_ss<CT>{days{1} - (sys_seconds{sd} - tp)}};
-  return to_stream(os, fmt, fds, &abbrev, &offset);
+std::basic_ostream<CharT, Traits>&
+to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
+          const sys_time<Duration>& tp)
+{
+    using std::chrono::seconds;
+    using CT = typename std::common_type<Duration, seconds>::type;
+    const std::string abbrev("UTC");
+    CONSTDATA seconds offset{0};
+    auto sd = std::chrono::time_point_cast<days>(tp);
+    fields<CT> fds;
+    if (sd <= tp)
+        fds = fields<CT>{year_month_day{sd}, hh_mm_ss<CT>{tp-sys_seconds{sd}}};
+    else
+        fds = fields<CT>{year_month_day{sd - days{1}},
+                         hh_mm_ss<CT>{days{1} - (sys_seconds{sd} - tp)}};
+    return to_stream(os, fmt, fds, &abbrev, &offset);
 }
 
 // format
 
 template <class CharT, class Streamable>
-auto format(const std::locale& loc, const CharT* fmt, const Streamable& tp)
+auto
+format(const std::locale& loc, const CharT* fmt, const Streamable& tp)
     -> decltype(to_stream(std::declval<std::basic_ostream<CharT>&>(), fmt, tp),
-                std::basic_string<CharT>{}) {
-  std::basic_ostringstream<CharT> os;
-  os.exceptions(std::ios::failbit | std::ios::badbit);
-  os.imbue(loc);
-  to_stream(os, fmt, tp);
-  return os.str();
+                std::basic_string<CharT>{})
+{
+    std::basic_ostringstream<CharT> os;
+    os.exceptions(std::ios::failbit | std::ios::badbit);
+    os.imbue(loc);
+    to_stream(os, fmt, tp);
+    return os.str();
 }
 
 template <class CharT, class Streamable>
-auto format(const CharT* fmt, const Streamable& tp)
+auto
+format(const CharT* fmt, const Streamable& tp)
     -> decltype(to_stream(std::declval<std::basic_ostream<CharT>&>(), fmt, tp),
-                std::basic_string<CharT>{}) {
-  std::basic_ostringstream<CharT> os;
-  os.exceptions(std::ios::failbit | std::ios::badbit);
-  to_stream(os, fmt, tp);
-  return os.str();
+                std::basic_string<CharT>{})
+{
+    std::basic_ostringstream<CharT> os;
+    os.exceptions(std::ios::failbit | std::ios::badbit);
+    to_stream(os, fmt, tp);
+    return os.str();
 }
 
 template <class CharT, class Traits, class Alloc, class Streamable>
-auto format(const std::locale& loc,
-            const std::basic_string<CharT, Traits, Alloc>& fmt,
-            const Streamable& tp)
-    -> decltype(to_stream(std::declval<std::basic_ostream<CharT, Traits>&>(),
-                          fmt.c_str(), tp),
-                std::basic_string<CharT, Traits, Alloc>{}) {
-  std::basic_ostringstream<CharT, Traits, Alloc> os;
-  os.exceptions(std::ios::failbit | std::ios::badbit);
-  os.imbue(loc);
-  to_stream(os, fmt.c_str(), tp);
-  return os.str();
+auto
+format(const std::locale& loc, const std::basic_string<CharT, Traits, Alloc>& fmt,
+       const Streamable& tp)
+    -> decltype(to_stream(std::declval<std::basic_ostream<CharT, Traits>&>(), fmt.c_str(), tp),
+                std::basic_string<CharT, Traits, Alloc>{})
+{
+    std::basic_ostringstream<CharT, Traits, Alloc> os;
+    os.exceptions(std::ios::failbit | std::ios::badbit);
+    os.imbue(loc);
+    to_stream(os, fmt.c_str(), tp);
+    return os.str();
 }
 
 template <class CharT, class Traits, class Alloc, class Streamable>
-auto format(const std::basic_string<CharT, Traits, Alloc>& fmt,
-            const Streamable& tp)
-    -> decltype(to_stream(std::declval<std::basic_ostream<CharT, Traits>&>(),
-                          fmt.c_str(), tp),
-                std::basic_string<CharT, Traits, Alloc>{}) {
-  std::basic_ostringstream<CharT, Traits, Alloc> os;
-  os.exceptions(std::ios::failbit | std::ios::badbit);
-  to_stream(os, fmt.c_str(), tp);
-  return os.str();
+auto
+format(const std::basic_string<CharT, Traits, Alloc>& fmt, const Streamable& tp)
+    -> decltype(to_stream(std::declval<std::basic_ostream<CharT, Traits>&>(), fmt.c_str(), tp),
+                std::basic_string<CharT, Traits, Alloc>{})
+{
+    std::basic_ostringstream<CharT, Traits, Alloc> os;
+    os.exceptions(std::ios::failbit | std::ios::badbit);
+    to_stream(os, fmt.c_str(), tp);
+    return os.str();
 }
 
 // parse
 
-namespace detail {
+namespace detail
+{
 
 template <class CharT, class Traits>
-bool read_char(std::basic_istream<CharT, Traits>& is, CharT fmt,
-               std::ios::iostate& err) {
-  auto ic = is.get();
-  if (Traits::eq_int_type(ic, Traits::eof()) ||
-      !Traits::eq(Traits::to_char_type(ic), fmt)) {
-    err |= std::ios::failbit;
-    is.setstate(std::ios::failbit);
-    return false;
-  }
-  return true;
-}
-
-template <class CharT, class Traits>
-unsigned read_unsigned(std::basic_istream<CharT, Traits>& is, unsigned m = 1,
-                       unsigned M = 10) {
-  unsigned x = 0;
-  unsigned count = 0;
-  while (true) {
-    auto ic = is.peek();
-    if (Traits::eq_int_type(ic, Traits::eof())) break;
-    auto c = static_cast<char>(Traits::to_char_type(ic));
-    if (!('0' <= c && c <= '9')) break;
-    (void)is.get();
-    ++count;
-    x = 10 * x + static_cast<unsigned>(c - '0');
-    if (count == M) break;
-  }
-  if (count < m) is.setstate(std::ios::failbit);
-  return x;
-}
-
-template <class CharT, class Traits>
-int read_signed(std::basic_istream<CharT, Traits>& is, unsigned m = 1,
-                unsigned M = 10) {
-  auto ic = is.peek();
-  if (!Traits::eq_int_type(ic, Traits::eof())) {
-    auto c = static_cast<char>(Traits::to_char_type(ic));
-    if (('0' <= c && c <= '9') || c == '-' || c == '+') {
-      if (c == '-' || c == '+') (void)is.get();
-      auto x = static_cast<int>(read_unsigned(is, std::max(m, 1u), M));
-      if (!is.fail()) {
-        if (c == '-') x = -x;
-        return x;
-      }
+bool
+read_char(std::basic_istream<CharT, Traits>& is, CharT fmt, std::ios::iostate& err)
+{
+    auto ic = is.get();
+    if (Traits::eq_int_type(ic, Traits::eof()) ||
+       !Traits::eq(Traits::to_char_type(ic), fmt))
+    {
+        err |= std::ios::failbit;
+        is.setstate(std::ios::failbit);
+        return false;
     }
-  }
-  if (m > 0) is.setstate(std::ios::failbit);
-  return 0;
+    return true;
 }
 
 template <class CharT, class Traits>
-long double read_long_double(std::basic_istream<CharT, Traits>& is,
-                             unsigned m = 1, unsigned M = 10) {
-  unsigned count = 0;
-  unsigned fcount = 0;
-  unsigned long long i = 0;
-  unsigned long long f = 0;
-  bool parsing_fraction = false;
-#if ONLY_C_LOCALE
-  typename Traits::int_type decimal_point = '.';
-#else
-  auto decimal_point = Traits::to_int_type(
-      std::use_facet<std::numpunct<CharT>>(is.getloc()).decimal_point());
-#endif
-  while (true) {
-    auto ic = is.peek();
-    if (Traits::eq_int_type(ic, Traits::eof())) break;
-    if (Traits::eq_int_type(ic, decimal_point)) {
-      decimal_point = Traits::eof();
-      parsing_fraction = true;
-    } else {
-      auto c = static_cast<char>(Traits::to_char_type(ic));
-      if (!('0' <= c && c <= '9')) break;
-      if (!parsing_fraction) {
-        i = 10 * i + static_cast<unsigned>(c - '0');
-      } else {
-        f = 10 * f + static_cast<unsigned>(c - '0');
-        ++fcount;
-      }
+unsigned
+read_unsigned(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned M = 10)
+{
+    unsigned x = 0;
+    unsigned count = 0;
+    while (true)
+    {
+        auto ic = is.peek();
+        if (Traits::eq_int_type(ic, Traits::eof()))
+            break;
+        auto c = static_cast<char>(Traits::to_char_type(ic));
+        if (!('0' <= c && c <= '9'))
+            break;
+        (void)is.get();
+        ++count;
+        x = 10*x + static_cast<unsigned>(c - '0');
+        if (count == M)
+            break;
     }
-    (void)is.get();
-    if (++count == M) break;
-  }
-  if (count < m) {
-    is.setstate(std::ios::failbit);
+    if (count < m)
+        is.setstate(std::ios::failbit);
+    return x;
+}
+
+template <class CharT, class Traits>
+int
+read_signed(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned M = 10)
+{
+    auto ic = is.peek();
+    if (!Traits::eq_int_type(ic, Traits::eof()))
+    {
+        auto c = static_cast<char>(Traits::to_char_type(ic));
+        if (('0' <= c && c <= '9') || c == '-' || c == '+')
+        {
+            if (c == '-' || c == '+')
+            {
+                (void)is.get();
+                --M;
+            }
+            auto x = static_cast<int>(read_unsigned(is, std::max(m, 1u), M));
+            if (!is.fail())
+            {
+                if (c == '-')
+                    x = -x;
+                return x;
+            }
+        }
+    }
+    if (m > 0)
+        is.setstate(std::ios::failbit);
     return 0;
-  }
-  return static_cast<long double>(i) +
-         static_cast<long double>(f) / std::pow(10.L, fcount);
 }
 
-struct rs {
-  int& i;
-  unsigned m;
-  unsigned M;
+template <class CharT, class Traits>
+long double
+read_long_double(std::basic_istream<CharT, Traits>& is, unsigned m = 1, unsigned M = 10)
+{
+    unsigned count = 0;
+    unsigned fcount = 0;
+    unsigned long long i = 0;
+    unsigned long long f = 0;
+    bool parsing_fraction = false;
+#if ONLY_C_LOCALE
+    typename Traits::int_type decimal_point = '.';
+#else
+    auto decimal_point = Traits::to_int_type(
+        std::use_facet<std::numpunct<CharT>>(is.getloc()).decimal_point());
+#endif
+    while (true)
+    {
+        auto ic = is.peek();
+        if (Traits::eq_int_type(ic, Traits::eof()))
+            break;
+        if (Traits::eq_int_type(ic, decimal_point))
+        {
+            decimal_point = Traits::eof();
+            parsing_fraction = true;
+        }
+        else
+        {
+            auto c = static_cast<char>(Traits::to_char_type(ic));
+            if (!('0' <= c && c <= '9'))
+                break;
+            if (!parsing_fraction)
+            {
+                i = 10*i + static_cast<unsigned>(c - '0');
+            }
+            else
+            {
+                f = 10*f + static_cast<unsigned>(c - '0');
+                ++fcount;
+            }
+        }
+        (void)is.get();
+        if (++count == M)
+            break;
+    }
+    if (count < m)
+    {
+        is.setstate(std::ios::failbit);
+        return 0;
+    }
+    return static_cast<long double>(i) + static_cast<long double>(f)/std::pow(10.L, fcount);
+}
+
+struct rs
+{
+    int& i;
+    unsigned m;
+    unsigned M;
 };
 
-struct ru {
-  int& i;
-  unsigned m;
-  unsigned M;
+struct ru
+{
+    int& i;
+    unsigned m;
+    unsigned M;
 };
 
-struct rld {
-  long double& i;
-  unsigned m;
-  unsigned M;
+struct rld
+{
+    long double& i;
+    unsigned m;
+    unsigned M;
 };
 
 template <class CharT, class Traits>
-void read(std::basic_istream<CharT, Traits>&) {}
+void
+read(std::basic_istream<CharT, Traits>&)
+{
+}
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, CharT a0, Args&&... args);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, CharT a0, Args&& ...args);
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, rs a0, Args&&... args);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, rs a0, Args&& ...args);
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, ru a0, Args&&... args);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, ru a0, Args&& ...args);
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, int a0, Args&&... args);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, int a0, Args&& ...args);
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, rld a0, Args&&... args);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, rld a0, Args&& ...args);
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, CharT a0, Args&&... args) {
-  // No-op if a0 == CharT{}
-  if (a0 != CharT{}) {
-    auto ic = is.peek();
-    if (Traits::eq_int_type(ic, Traits::eof())) {
-      is.setstate(std::ios::failbit | std::ios::eofbit);
-      return;
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, CharT a0, Args&& ...args)
+{
+    // No-op if a0 == CharT{}
+    if (a0 != CharT{})
+    {
+        auto ic = is.peek();
+        if (Traits::eq_int_type(ic, Traits::eof()))
+        {
+            is.setstate(std::ios::failbit | std::ios::eofbit);
+            return;
+        }
+        if (!Traits::eq(Traits::to_char_type(ic), a0))
+        {
+            is.setstate(std::ios::failbit);
+            return;
+        }
+        (void)is.get();
     }
-    if (!Traits::eq(Traits::to_char_type(ic), a0)) {
-      is.setstate(std::ios::failbit);
-      return;
+    read(is, std::forward<Args>(args)...);
+}
+
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, rs a0, Args&& ...args)
+{
+    auto x = read_signed(is, a0.m, a0.M);
+    if (is.fail())
+        return;
+    a0.i = x;
+    read(is, std::forward<Args>(args)...);
+}
+
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, ru a0, Args&& ...args)
+{
+    auto x = read_unsigned(is, a0.m, a0.M);
+    if (is.fail())
+        return;
+    a0.i = static_cast<int>(x);
+    read(is, std::forward<Args>(args)...);
+}
+
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, int a0, Args&& ...args)
+{
+    if (a0 != -1)
+    {
+        auto u = static_cast<unsigned>(a0);
+        CharT buf[std::numeric_limits<unsigned>::digits10+2u] = {};
+        auto e = buf;
+        do
+        {
+            *e++ = static_cast<CharT>(CharT(u % 10) + CharT{'0'});
+            u /= 10;
+        } while (u > 0);
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
+        std::reverse(buf, e);
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+        for (auto p = buf; p != e && is.rdstate() == std::ios::goodbit; ++p)
+            read(is, *p);
     }
-    (void)is.get();
-  }
-  read(is, std::forward<Args>(args)...);
+    if (is.rdstate() == std::ios::goodbit)
+        read(is, std::forward<Args>(args)...);
 }
 
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, rs a0, Args&&... args) {
-  auto x = read_signed(is, a0.m, a0.M);
-  if (is.fail()) return;
-  a0.i = x;
-  read(is, std::forward<Args>(args)...);
-}
-
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, ru a0, Args&&... args) {
-  auto x = read_unsigned(is, a0.m, a0.M);
-  if (is.fail()) return;
-  a0.i = static_cast<int>(x);
-  read(is, std::forward<Args>(args)...);
-}
-
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, int a0, Args&&... args) {
-  if (a0 != -1) {
-    auto u = static_cast<unsigned>(a0);
-    CharT buf[std::numeric_limits<unsigned>::digits10 + 2u] = {};
-    auto e = buf;
-    do {
-      *e++ = static_cast<CharT>(CharT(u % 10) + CharT{'0'});
-      u /= 10;
-    } while (u > 0);
-    std::reverse(buf, e);
-    for (auto p = buf; p != e && is.rdstate() == std::ios::goodbit; ++p)
-      read(is, *p);
-  }
-  if (is.rdstate() == std::ios::goodbit) read(is, std::forward<Args>(args)...);
-}
-
-template <class CharT, class Traits, class... Args>
-void read(std::basic_istream<CharT, Traits>& is, rld a0, Args&&... args) {
-  auto x = read_long_double(is, a0.m, a0.M);
-  if (is.fail()) return;
-  a0.i = x;
-  read(is, std::forward<Args>(args)...);
+template <class CharT, class Traits, class ...Args>
+void
+read(std::basic_istream<CharT, Traits>& is, rld a0, Args&& ...args)
+{
+    auto x = read_long_double(is, a0.m, a0.M);
+    if (is.fail())
+        return;
+    a0.i = x;
+    read(is, std::forward<Args>(args)...);
 }
 
 template <class T, class CharT, class Traits>
-inline void checked_set(T& value, T from, T not_a_value,
-                        std::basic_ios<CharT, Traits>& is) {
-  if (!is.fail()) {
-    if (value == not_a_value)
-      value = std::move(from);
-    else if (value != from)
-      is.setstate(std::ios::failbit);
-  }
+inline
+void
+checked_set(T& value, T from, T not_a_value, std::basic_ios<CharT, Traits>& is)
+{
+    if (!is.fail())
+    {
+        if (value == not_a_value)
+            value = std::move(from);
+        else if (value != from)
+            is.setstate(std::ios::failbit);
+    }
 }
 
-}  // namespace detail
+}  // namespace detail;
 
-template <class CharT, class Traits, class Duration,
-          class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    fields<Duration>& fds, std::basic_string<CharT, Traits, Alloc>* abbrev,
-    std::chrono::minutes* offset) {
-  using detail::round_i;
-  using std::ios;
-  using std::numeric_limits;
-  using std::chrono::duration;
-  using std::chrono::duration_cast;
-  using std::chrono::hours;
-  using std::chrono::minutes;
-  using std::chrono::seconds;
-  typename std::basic_istream<CharT, Traits>::sentry ok{is, true};
-  if (ok) {
-    date::detail::save_istream<CharT, Traits> ss(is);
-    is.fill(' ');
-    is.flags(std::ios::skipws | std::ios::dec);
-    is.width(0);
+template <class CharT, class Traits, class Duration, class Alloc = std::allocator<CharT>>
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            fields<Duration>& fds, std::basic_string<CharT, Traits, Alloc>* abbrev,
+            std::chrono::minutes* offset)
+{
+    using std::numeric_limits;
+    using std::ios;
+    using std::chrono::duration;
+    using std::chrono::duration_cast;
+    using std::chrono::seconds;
+    using std::chrono::minutes;
+    using std::chrono::hours;
+    using detail::round_i;
+    typename std::basic_istream<CharT, Traits>::sentry ok{is, true};
+    if (ok)
+    {
+        date::detail::save_istream<CharT, Traits> ss(is);
+        is.fill(' ');
+        is.flags(std::ios::skipws | std::ios::dec);
+        is.width(0);
 #if !ONLY_C_LOCALE
-    auto& f = std::use_facet<std::time_get<CharT>>(is.getloc());
-    std::tm tm{};
+        auto& f = std::use_facet<std::time_get<CharT>>(is.getloc());
+        std::tm tm{};
 #endif
-    const CharT* command = nullptr;
-    auto modified = CharT{};
-    auto width = -1;
+        const CharT* command = nullptr;
+        auto modified = CharT{};
+        auto width = -1;
 
-    CONSTDATA int not_a_year = numeric_limits<short>::min();
-    CONSTDATA int not_a_2digit_year = 100;
-    CONSTDATA int not_a_century = not_a_year / 100;
-    CONSTDATA int not_a_month = 0;
-    CONSTDATA int not_a_day = 0;
-    CONSTDATA int not_a_hour = numeric_limits<int>::min();
-    CONSTDATA int not_a_hour_12_value = 0;
-    CONSTDATA int not_a_minute = not_a_hour;
-    CONSTDATA Duration not_a_second = Duration::min();
-    CONSTDATA int not_a_doy = -1;
-    CONSTDATA int not_a_weekday = 8;
-    CONSTDATA int not_a_week_num = 100;
-    CONSTDATA int not_a_ampm = -1;
-    CONSTDATA minutes not_a_offset = minutes::min();
+        CONSTDATA int not_a_year = numeric_limits<short>::min();
+        CONSTDATA int not_a_2digit_year = 100;
+        CONSTDATA int not_a_century = numeric_limits<int>::min();
+        CONSTDATA int not_a_month = 0;
+        CONSTDATA int not_a_day = 0;
+        CONSTDATA int not_a_hour = numeric_limits<int>::min();
+        CONSTDATA int not_a_hour_12_value = 0;
+        CONSTDATA int not_a_minute = not_a_hour;
+        CONSTDATA Duration not_a_second = Duration::min();
+        CONSTDATA int not_a_doy = -1;
+        CONSTDATA int not_a_weekday = 8;
+        CONSTDATA int not_a_week_num = 100;
+        CONSTDATA int not_a_ampm = -1;
+        CONSTDATA minutes not_a_offset = minutes::min();
 
-    int Y = not_a_year;           // c, F, Y                   *
-    int y = not_a_2digit_year;    // D, x, y                   *
-    int g = not_a_2digit_year;    // g                         *
-    int G = not_a_year;           // G                         *
-    int C = not_a_century;        // C                         *
-    int m = not_a_month;          // b, B, h, m, c, D, F, x    *
-    int d = not_a_day;            // c, d, D, e, F, x          *
-    int j = not_a_doy;            // j                         *
-    int wd = not_a_weekday;       // a, A, u, w                *
-    int H = not_a_hour;           // c, H, R, T, X             *
-    int I = not_a_hour_12_value;  // I, r                      *
-    int p = not_a_ampm;           // p, r                      *
-    int M = not_a_minute;         // c, M, r, R, T, X          *
-    Duration s = not_a_second;    // c, r, S, T, X             *
-    int U = not_a_week_num;       // U                         *
-    int V = not_a_week_num;       // V                         *
-    int W = not_a_week_num;       // W                         *
-    std::basic_string<CharT, Traits, Alloc> temp_abbrev;  // Z   *
-    minutes temp_offset = not_a_offset;  // z                    *
+        int Y = not_a_year;             // c, F, Y                   *
+        int y = not_a_2digit_year;      // D, x, y                   *
+        int g = not_a_2digit_year;      // g                         *
+        int G = not_a_year;             // G                         *
+        int C = not_a_century;          // C                         *
+        int m = not_a_month;            // b, B, h, m, c, D, F, x    *
+        int d = not_a_day;              // c, d, D, e, F, x          *
+        int j = not_a_doy;              // j                         *
+        int wd = not_a_weekday;         // a, A, u, w                *
+        int H = not_a_hour;             // c, H, R, T, X             *
+        int I = not_a_hour_12_value;    // I, r                      *
+        int p = not_a_ampm;             // p, r                      *
+        int M = not_a_minute;           // c, M, r, R, T, X          *
+        Duration s = not_a_second;      // c, r, S, T, X             *
+        int U = not_a_week_num;         // U                         *
+        int V = not_a_week_num;         // V                         *
+        int W = not_a_week_num;         // W                         *
+        std::basic_string<CharT, Traits, Alloc> temp_abbrev;  // Z   *
+        minutes temp_offset = not_a_offset;  // z                    *
 
-    using detail::checked_set;
-    using detail::read;
-    using detail::rld;
-    using detail::rs;
-    using detail::ru;
-    for (; *fmt != CharT{} && !is.fail(); ++fmt) {
-      switch (*fmt) {
-        case 'a':
-        case 'A':
-        case 'u':
-        case 'w':  // wd:  a, A, u, w
-          if (command) {
-            int trial_wd = not_a_weekday;
-            if (*fmt == 'a' || *fmt == 'A') {
-              if (modified == CharT{}) {
-#if !ONLY_C_LOCALE
-                ios::iostate err = ios::goodbit;
-                f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-                is.setstate(err);
-                if (!is.fail()) trial_wd = tm.tm_wday;
-#else
-                auto nm = detail::weekday_names();
-                auto i =
-                    detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-                if (!is.fail()) trial_wd = i % 7;
-#endif
-              } else
-                read(is, CharT{'%'}, width, modified, *fmt);
-            } else  // *fmt == 'u' || *fmt == 'w'
-            {
-#if !ONLY_C_LOCALE
-              if (modified == CharT{})
-#else
-              if (modified != CharT{'E'})
-#endif
-              {
-                read(is, ru{trial_wd, 1,
-                            width == -1 ? 1u : static_cast<unsigned>(width)});
-                if (!is.fail()) {
-                  if (*fmt == 'u') {
-                    if (!(1 <= trial_wd && trial_wd <= 7)) {
-                      trial_wd = not_a_weekday;
-                      is.setstate(ios::failbit);
-                    } else if (trial_wd == 7)
-                      trial_wd = 0;
-                  } else  // *fmt == 'w'
-                  {
-                    if (!(0 <= trial_wd && trial_wd <= 6)) {
-                      trial_wd = not_a_weekday;
-                      is.setstate(ios::failbit);
-                    }
-                  }
-                }
-              }
-#if !ONLY_C_LOCALE
-              else if (modified == CharT{'O'}) {
-                ios::iostate err = ios::goodbit;
-                f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-                is.setstate(err);
-                if (!is.fail()) trial_wd = tm.tm_wday;
-              }
-#endif
-              else
-                read(is, CharT{'%'}, width, modified, *fmt);
-            }
-            if (trial_wd != not_a_weekday)
-              checked_set(wd, trial_wd, not_a_weekday, is);
-          } else  // !command
-            read(is, *fmt);
-          command = nullptr;
-          width = -1;
-          modified = CharT{};
-          break;
-        case 'b':
-        case 'B':
-        case 'h':
-          if (command) {
-            if (modified == CharT{}) {
-              int ttm = not_a_month;
-#if !ONLY_C_LOCALE
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) ttm = tm.tm_mon + 1;
-              is.setstate(err);
-#else
-              auto nm = detail::month_names();
-              auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-              if (!is.fail()) ttm = i % 12 + 1;
-#endif
-              checked_set(m, ttm, not_a_month, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'c':
-          if (command) {
-            if (modified != CharT{'O'}) {
-#if !ONLY_C_LOCALE
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) {
-                checked_set(Y, tm.tm_year + 1900, not_a_year, is);
-                checked_set(m, tm.tm_mon + 1, not_a_month, is);
-                checked_set(d, tm.tm_mday, not_a_day, is);
-                checked_set(H, tm.tm_hour, not_a_hour, is);
-                checked_set(M, tm.tm_min, not_a_minute, is);
-                checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
-                            not_a_second, is);
-              }
-              is.setstate(err);
-#else
-              // "%a %b %e %T %Y"
-              auto nm = detail::weekday_names();
-              auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-              checked_set(wd, static_cast<int>(i % 7), not_a_weekday, is);
-              ws(is);
-              nm = detail::month_names();
-              i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-              checked_set(m, static_cast<int>(i % 12 + 1), not_a_month, is);
-              ws(is);
-              int td = not_a_day;
-              read(is, rs{td, 1, 2});
-              checked_set(d, td, not_a_day, is);
-              ws(is);
-              using dfs = detail::decimal_format_seconds<Duration>;
-              CONSTDATA auto w =
-                  Duration::period::den == 1 ? 2 : 3 + dfs::width;
-              int tH;
-              int tM;
-              long double S{};
-              read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2}, CharT{':'},
-                   rld{S, 1, w});
-              checked_set(H, tH, not_a_hour, is);
-              checked_set(M, tM, not_a_minute, is);
-              checked_set(s, round_i<Duration>(duration<long double>{S}),
-                          not_a_second, is);
-              ws(is);
-              int tY = not_a_year;
-              read(is, rs{tY, 1, 4u});
-              checked_set(Y, tY, not_a_year, is);
-#endif
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'x':
-          if (command) {
-            if (modified != CharT{'O'}) {
-#if !ONLY_C_LOCALE
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) {
-                checked_set(Y, tm.tm_year + 1900, not_a_year, is);
-                checked_set(m, tm.tm_mon + 1, not_a_month, is);
-                checked_set(d, tm.tm_mday, not_a_day, is);
-              }
-              is.setstate(err);
-#else
-              // "%m/%d/%y"
-              int ty = not_a_2digit_year;
-              int tm = not_a_month;
-              int td = not_a_day;
-              read(is, ru{tm, 1, 2}, CharT{'/'}, ru{td, 1, 2}, CharT{'/'},
-                   rs{ty, 1, 2});
-              checked_set(y, ty, not_a_2digit_year, is);
-              checked_set(m, tm, not_a_month, is);
-              checked_set(d, td, not_a_day, is);
-#endif
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'X':
-          if (command) {
-            if (modified != CharT{'O'}) {
-#if !ONLY_C_LOCALE
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) {
-                checked_set(H, tm.tm_hour, not_a_hour, is);
-                checked_set(M, tm.tm_min, not_a_minute, is);
-                checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
-                            not_a_second, is);
-              }
-              is.setstate(err);
-#else
-              // "%T"
-              using dfs = detail::decimal_format_seconds<Duration>;
-              CONSTDATA auto w =
-                  Duration::period::den == 1 ? 2 : 3 + dfs::width;
-              int tH = not_a_hour;
-              int tM = not_a_minute;
-              long double S{};
-              read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2}, CharT{':'},
-                   rld{S, 1, w});
-              checked_set(H, tH, not_a_hour, is);
-              checked_set(M, tM, not_a_minute, is);
-              checked_set(s, round_i<Duration>(duration<long double>{S}),
-                          not_a_second, is);
-#endif
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'C':
-          if (command) {
-            int tC = not_a_century;
-#if !ONLY_C_LOCALE
-            if (modified == CharT{}) {
-#endif
-              read(is,
-                   rs{tC, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-#if !ONLY_C_LOCALE
-            } else {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) {
-                auto tY = tm.tm_year + 1900;
-                tC = (tY >= 0 ? tY : tY - 99) / 100;
-              }
-              is.setstate(err);
-            }
-#endif
-            checked_set(C, tC, not_a_century, is);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'D':
-          if (command) {
-            if (modified == CharT{}) {
-              int tn = not_a_month;
-              int td = not_a_day;
-              int ty = not_a_2digit_year;
-              read(is, ru{tn, 1, 2}, CharT{'\0'}, CharT{'/'}, CharT{'\0'},
-                   ru{td, 1, 2}, CharT{'\0'}, CharT{'/'}, CharT{'\0'},
-                   rs{ty, 1, 2});
-              checked_set(y, ty, not_a_2digit_year, is);
-              checked_set(m, tn, not_a_month, is);
-              checked_set(d, td, not_a_day, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'F':
-          if (command) {
-            if (modified == CharT{}) {
-              int tY = not_a_year;
-              int tn = not_a_month;
-              int td = not_a_day;
-              read(is,
-                   rs{tY, 1, width == -1 ? 4u : static_cast<unsigned>(width)},
-                   CharT{'-'}, ru{tn, 1, 2}, CharT{'-'}, ru{td, 1, 2});
-              checked_set(Y, tY, not_a_year, is);
-              checked_set(m, tn, not_a_month, is);
-              checked_set(d, td, not_a_day, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'd':
-        case 'e':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'E'})
-#endif
-            {
-              int td = not_a_day;
-              read(is,
-                   rs{td, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(d, td, not_a_day, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              command = nullptr;
-              width = -1;
-              modified = CharT{};
-              if ((err & ios::failbit) == 0)
-                checked_set(d, tm.tm_mday, not_a_day, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'H':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'E'})
-#endif
-            {
-              int tH = not_a_hour;
-              read(is,
-                   ru{tH, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(H, tH, not_a_hour, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(H, tm.tm_hour, not_a_hour, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'I':
-          if (command) {
-            if (modified == CharT{}) {
-              int tI = not_a_hour_12_value;
-              // reads in an hour into I, but most be in [1, 12]
-              read(is,
-                   rs{tI, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              if (!(1 <= tI && tI <= 12)) is.setstate(ios::failbit);
-              checked_set(I, tI, not_a_hour_12_value, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'j':
-          if (command) {
-            if (modified == CharT{}) {
-              int tj = not_a_doy;
-              read(is,
-                   ru{tj, 1, width == -1 ? 3u : static_cast<unsigned>(width)});
-              checked_set(j, tj, not_a_doy, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'M':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'E'})
-#endif
-            {
-              int tM = not_a_minute;
-              read(is,
-                   ru{tM, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(M, tM, not_a_minute, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(M, tm.tm_min, not_a_minute, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'm':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'E'})
-#endif
-            {
-              int tn = not_a_month;
-              read(is,
-                   rs{tn, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(m, tn, not_a_month, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(m, tm.tm_mon + 1, not_a_month, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'n':
-        case 't':
-          if (command) {
-            if (modified == CharT{}) {
-              // %n matches a single white space character
-              // %t matches 0 or 1 white space characters
-              auto ic = is.peek();
-              if (Traits::eq_int_type(ic, Traits::eof())) {
-                ios::iostate err = ios::eofbit;
-                if (*fmt == 'n') err |= ios::failbit;
-                is.setstate(err);
-                break;
-              }
-              if (isspace(ic)) {
-                (void)is.get();
-              } else if (*fmt == 'n')
-                is.setstate(ios::failbit);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'p':
-          if (command) {
-            if (modified == CharT{}) {
-              int tp = not_a_ampm;
-#if !ONLY_C_LOCALE
-              tm = std::tm{};
-              tm.tm_hour = 1;
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              is.setstate(err);
-              if (tm.tm_hour == 1)
-                tp = 0;
-              else if (tm.tm_hour == 13)
-                tp = 1;
-              else
-                is.setstate(err);
-#else
-              auto nm = detail::ampm_names();
-              auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-              tp = static_cast<decltype(tp)>(i);
-#endif
-              checked_set(p, tp, not_a_ampm, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-
-          break;
-        case 'r':
-          if (command) {
-            if (modified == CharT{}) {
-#if !ONLY_C_LOCALE
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0) {
-                checked_set(H, tm.tm_hour, not_a_hour, is);
-                checked_set(M, tm.tm_min, not_a_hour, is);
-                checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
-                            not_a_second, is);
-              }
-              is.setstate(err);
-#else
-              // "%I:%M:%S %p"
-              using dfs = detail::decimal_format_seconds<Duration>;
-              CONSTDATA auto w =
-                  Duration::period::den == 1 ? 2 : 3 + dfs::width;
-              long double S{};
-              int tI = not_a_hour_12_value;
-              int tM = not_a_minute;
-              read(is, ru{tI, 1, 2}, CharT{':'}, ru{tM, 1, 2}, CharT{':'},
-                   rld{S, 1, w});
-              checked_set(I, tI, not_a_hour_12_value, is);
-              checked_set(M, tM, not_a_minute, is);
-              checked_set(s, round_i<Duration>(duration<long double>{S}),
-                          not_a_second, is);
-              ws(is);
-              auto nm = detail::ampm_names();
-              auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
-              checked_set(p, static_cast<int>(i), not_a_ampm, is);
-#endif
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'R':
-          if (command) {
-            if (modified == CharT{}) {
-              int tH = not_a_hour;
-              int tM = not_a_minute;
-              read(is, ru{tH, 1, 2}, CharT{'\0'}, CharT{':'}, CharT{'\0'},
-                   ru{tM, 1, 2}, CharT{'\0'});
-              checked_set(H, tH, not_a_hour, is);
-              checked_set(M, tM, not_a_minute, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'S':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'E'})
-#endif
-            {
-              using dfs = detail::decimal_format_seconds<Duration>;
-              CONSTDATA auto w =
-                  Duration::period::den == 1 ? 2 : 3 + dfs::width;
-              long double S{};
-              read(is,
-                   rld{S, 1, width == -1 ? w : static_cast<unsigned>(width)});
-              checked_set(s, round_i<Duration>(duration<long double>{S}),
-                          not_a_second, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'O'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
-                            not_a_second, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'T':
-          if (command) {
-            if (modified == CharT{}) {
-              using dfs = detail::decimal_format_seconds<Duration>;
-              CONSTDATA auto w =
-                  Duration::period::den == 1 ? 2 : 3 + dfs::width;
-              int tH = not_a_hour;
-              int tM = not_a_minute;
-              long double S{};
-              read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2}, CharT{':'},
-                   rld{S, 1, w});
-              checked_set(H, tH, not_a_hour, is);
-              checked_set(M, tM, not_a_minute, is);
-              checked_set(s, round_i<Duration>(duration<long double>{S}),
-                          not_a_second, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'Y':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#else
-            if (modified != CharT{'O'})
-#endif
-            {
-              int tY = not_a_year;
-              read(is,
-                   rs{tY, 1, width == -1 ? 4u : static_cast<unsigned>(width)});
-              checked_set(Y, tY, not_a_year, is);
-            }
-#if !ONLY_C_LOCALE
-            else if (modified == CharT{'E'}) {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(Y, tm.tm_year + 1900, not_a_year, is);
-              is.setstate(err);
-            }
-#endif
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'y':
-          if (command) {
-#if !ONLY_C_LOCALE
-            if (modified == CharT{})
-#endif
-            {
-              int ty = not_a_2digit_year;
-              read(is,
-                   ru{ty, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(y, ty, not_a_2digit_year, is);
-            }
-#if !ONLY_C_LOCALE
-            else {
-              ios::iostate err = ios::goodbit;
-              f.get(is, nullptr, is, err, &tm, command, fmt + 1);
-              if ((err & ios::failbit) == 0)
-                checked_set(Y, tm.tm_year + 1900, not_a_year, is);
-              is.setstate(err);
-            }
-#endif
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'g':
-          if (command) {
-            if (modified == CharT{}) {
-              int tg = not_a_2digit_year;
-              read(is,
-                   ru{tg, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(g, tg, not_a_2digit_year, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'G':
-          if (command) {
-            if (modified == CharT{}) {
-              int tG = not_a_year;
-              read(is,
-                   rs{tG, 1, width == -1 ? 4u : static_cast<unsigned>(width)});
-              checked_set(G, tG, not_a_year, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'U':
-          if (command) {
-            if (modified == CharT{}) {
-              int tU = not_a_week_num;
-              read(is,
-                   ru{tU, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(U, tU, not_a_week_num, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'V':
-          if (command) {
-            if (modified == CharT{}) {
-              int tV = not_a_week_num;
-              read(is,
-                   ru{tV, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(V, tV, not_a_week_num, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'W':
-          if (command) {
-            if (modified == CharT{}) {
-              int tW = not_a_week_num;
-              read(is,
-                   ru{tW, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
-              checked_set(W, tW, not_a_week_num, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'E':
-        case 'O':
-          if (command) {
-            if (modified == CharT{}) {
-              modified = *fmt;
-            } else {
-              read(is, CharT{'%'}, width, modified, *fmt);
-              command = nullptr;
-              width = -1;
-              modified = CharT{};
-            }
-          } else
-            read(is, *fmt);
-          break;
-        case '%':
-          if (command) {
-            if (modified == CharT{})
-              read(is, *fmt);
-            else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            command = fmt;
-          break;
-        case 'z':
-          if (command) {
-            int tH, tM;
-            minutes toff = not_a_offset;
-            bool neg = false;
-            auto ic = is.peek();
-            if (!Traits::eq_int_type(ic, Traits::eof())) {
-              auto c = static_cast<char>(Traits::to_char_type(ic));
-              if (c == '-') neg = true;
-            }
-            if (modified == CharT{}) {
-              read(is, rs{tH, 2, 2});
-              if (!is.fail()) toff = hours{std::abs(tH)};
-              if (is.good()) {
-                ic = is.peek();
-                if (!Traits::eq_int_type(ic, Traits::eof())) {
-                  auto c = static_cast<char>(Traits::to_char_type(ic));
-                  if ('0' <= c && c <= '9') {
-                    read(is, ru{tM, 2, 2});
-                    if (!is.fail()) toff += minutes{tM};
-                  }
-                }
-              }
-            } else {
-              read(is, rs{tH, 1, 2});
-              if (!is.fail()) toff = hours{std::abs(tH)};
-              if (is.good()) {
-                ic = is.peek();
-                if (!Traits::eq_int_type(ic, Traits::eof())) {
-                  auto c = static_cast<char>(Traits::to_char_type(ic));
-                  if (c == ':') {
-                    (void)is.get();
-                    read(is, ru{tM, 2, 2});
-                    if (!is.fail()) toff += minutes{tM};
-                  }
-                }
-              }
-            }
-            if (neg) toff = -toff;
-            checked_set(temp_offset, toff, not_a_offset, is);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        case 'Z':
-          if (command) {
-            if (modified == CharT{}) {
-              std::basic_string<CharT, Traits, Alloc> buf;
-              while (is.rdstate() == std::ios::goodbit) {
-                auto i = is.rdbuf()->sgetc();
-                if (Traits::eq_int_type(i, Traits::eof())) {
-                  is.setstate(ios::eofbit);
-                  break;
-                }
-                auto wc = Traits::to_char_type(i);
-                auto c = static_cast<char>(wc);
-                // is c a valid time zone name or abbreviation character?
-                if (!(CharT{1} < wc && wc < CharT{127}) ||
-                    !(isalnum(c) || c == '_' || c == '/' || c == '-' ||
-                      c == '+'))
-                  break;
-                buf.push_back(c);
-                is.rdbuf()->sbumpc();
-              }
-              if (buf.empty()) is.setstate(ios::failbit);
-              checked_set(temp_abbrev, buf, {}, is);
-            } else
-              read(is, CharT{'%'}, width, modified, *fmt);
-            command = nullptr;
-            width = -1;
-            modified = CharT{};
-          } else
-            read(is, *fmt);
-          break;
-        default:
-          if (command) {
-            if (width == -1 && modified == CharT{} && '0' <= *fmt &&
-                *fmt <= '9') {
-              width = static_cast<char>(*fmt) - '0';
-              while ('0' <= fmt[1] && fmt[1] <= '9')
-                width = 10 * width + static_cast<char>(*++fmt) - '0';
-            } else {
-              if (modified == CharT{})
-                read(is, CharT{'%'}, width, *fmt);
-              else
-                read(is, CharT{'%'}, width, modified, *fmt);
-              command = nullptr;
-              width = -1;
-              modified = CharT{};
-            }
-          } else  // !command
-          {
-            if (isspace(static_cast<unsigned char>(*fmt))) {
-              // space matches 0 or more white space characters
-              if (is.good()) ws(is);
-            } else
-              read(is, *fmt);
-          }
-          break;
-      }
-    }
-    // is.fail() || *fmt == CharT{}
-    if (is.rdstate() == ios::goodbit && command) {
-      if (modified == CharT{})
-        read(is, CharT{'%'}, width);
-      else
-        read(is, CharT{'%'}, width, modified);
-    }
-    if (!is.fail()) {
-      if (y != not_a_2digit_year) {
-        // Convert y and an optional C to Y
-        if (!(0 <= y && y <= 99)) goto broken;
-        if (C == not_a_century) {
-          if (Y == not_a_year) {
-            if (y >= 69)
-              C = 19;
-            else
-              C = 20;
-          } else {
-            C = (Y >= 0 ? Y : Y - 100) / 100;
-          }
-        }
-        int tY;
-        if (C >= 0)
-          tY = 100 * C + y;
-        else
-          tY = 100 * (C + 1) - (y == 0 ? 100 : y);
-        if (Y != not_a_year && Y != tY) goto broken;
-        Y = tY;
-      }
-      if (g != not_a_2digit_year) {
-        // Convert g and an optional C to G
-        if (!(0 <= g && g <= 99)) goto broken;
-        if (C == not_a_century) {
-          if (G == not_a_year) {
-            if (g >= 69)
-              C = 19;
-            else
-              C = 20;
-          } else {
-            C = (G >= 0 ? G : G - 100) / 100;
-          }
-        }
-        int tG;
-        if (C >= 0)
-          tG = 100 * C + g;
-        else
-          tG = 100 * (C + 1) - (g == 0 ? 100 : g);
-        if (G != not_a_year && G != tG) goto broken;
-        G = tG;
-      }
-      if (Y < static_cast<int>(year::min()) ||
-          Y > static_cast<int>(year::max()))
-        Y = not_a_year;
-      bool computed = false;
-      if (G != not_a_year && V != not_a_week_num && wd != not_a_weekday) {
-        year_month_day ymd_trial =
-            sys_days(year{G - 1} / December / Thursday[last]) +
-            (Monday - Thursday) + weeks{V - 1} +
-            (weekday{static_cast<unsigned>(wd)} - Monday);
-        if (Y == not_a_year)
-          Y = static_cast<int>(ymd_trial.year());
-        else if (year{Y} != ymd_trial.year())
-          goto broken;
-        if (m == not_a_month)
-          m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
-        else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
-          goto broken;
-        if (d == not_a_day)
-          d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
-        else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
-          goto broken;
-        computed = true;
-      }
-      if (Y != not_a_year && U != not_a_week_num && wd != not_a_weekday) {
-        year_month_day ymd_trial =
-            sys_days(year{Y} / January / Sunday[1]) + weeks{U - 1} +
-            (weekday{static_cast<unsigned>(wd)} - Sunday);
-        if (Y == not_a_year)
-          Y = static_cast<int>(ymd_trial.year());
-        else if (year{Y} != ymd_trial.year())
-          goto broken;
-        if (m == not_a_month)
-          m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
-        else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
-          goto broken;
-        if (d == not_a_day)
-          d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
-        else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
-          goto broken;
-        computed = true;
-      }
-      if (Y != not_a_year && W != not_a_week_num && wd != not_a_weekday) {
-        year_month_day ymd_trial =
-            sys_days(year{Y} / January / Monday[1]) + weeks{W - 1} +
-            (weekday{static_cast<unsigned>(wd)} - Monday);
-        if (Y == not_a_year)
-          Y = static_cast<int>(ymd_trial.year());
-        else if (year{Y} != ymd_trial.year())
-          goto broken;
-        if (m == not_a_month)
-          m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
-        else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
-          goto broken;
-        if (d == not_a_day)
-          d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
-        else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
-          goto broken;
-        computed = true;
-      }
-      if (j != not_a_doy && Y != not_a_year) {
-        auto ymd_trial =
-            year_month_day{local_days(year{Y} / 1 / 1) + days{j - 1}};
-        if (m == not_a_month)
-          m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
-        else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
-          goto broken;
-        if (d == not_a_day)
-          d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
-        else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
-          goto broken;
-        j = not_a_doy;
-      }
-      auto ymd = year{Y} / m / d;
-      if (ymd.ok()) {
-        if (wd == not_a_weekday)
-          wd = static_cast<int>((weekday(sys_days(ymd)) - Sunday).count());
-        else if (wd !=
-                 static_cast<int>((weekday(sys_days(ymd)) - Sunday).count()))
-          goto broken;
-        if (!computed) {
-          if (G != not_a_year || V != not_a_week_num) {
-            sys_days sd = ymd;
-            auto G_trial = year_month_day{sd + days{3}}.year();
-            auto start =
-                sys_days((G_trial - years{1}) / December / Thursday[last]) +
-                (Monday - Thursday);
-            if (sd < start) {
-              --G_trial;
-              if (V != not_a_week_num)
-                start =
-                    sys_days((G_trial - years{1}) / December / Thursday[last]) +
-                    (Monday - Thursday);
-            }
-            if (G != not_a_year && G != static_cast<int>(G_trial)) goto broken;
-            if (V != not_a_week_num) {
-              auto V_trial = duration_cast<weeks>(sd - start).count() + 1;
-              if (V != V_trial) goto broken;
-            }
-          }
-          if (U != not_a_week_num) {
-            auto start = sys_days(Sunday[1] / January / ymd.year());
-            auto U_trial = floor<weeks>(sys_days(ymd) - start).count() + 1;
-            if (U != U_trial) goto broken;
-          }
-          if (W != not_a_week_num) {
-            auto start = sys_days(Monday[1] / January / ymd.year());
-            auto W_trial = floor<weeks>(sys_days(ymd) - start).count() + 1;
-            if (W != W_trial) goto broken;
-          }
-        }
-      }
-      fds.ymd = ymd;
-      if (I != not_a_hour_12_value) {
-        if (!(1 <= I && I <= 12)) goto broken;
-        if (p != not_a_ampm) {
-          // p is in [0, 1] == [AM, PM]
-          // Store trial H in I
-          if (I == 12) --p;
-          I += p * 12;
-          // Either set H from I or make sure H and I are consistent
-          if (H == not_a_hour)
-            H = I;
-          else if (I != H)
-            goto broken;
-        } else  // p == not_a_ampm
+        using detail::read;
+        using detail::rs;
+        using detail::ru;
+        using detail::rld;
+        using detail::checked_set;
+        for (; *fmt != CharT{} && !is.fail(); ++fmt)
         {
-          // if H, make sure H and I could be consistent
-          if (H != not_a_hour) {
-            if (I == 12) {
-              if (H != 0 && H != 12) goto broken;
-            } else if (!(I == H || I == H + 12)) {
-              goto broken;
+            switch (*fmt)
+            {
+            case 'a':
+            case 'A':
+            case 'u':
+            case 'w':  // wd:  a, A, u, w
+                if (command)
+                {
+                    int trial_wd = not_a_weekday;
+                    if (*fmt == 'a' || *fmt == 'A')
+                    {
+                        if (modified == CharT{})
+                        {
+#if !ONLY_C_LOCALE
+                            ios::iostate err = ios::goodbit;
+                            f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                            is.setstate(err);
+                            if (!is.fail())
+                                trial_wd = tm.tm_wday;
+#else
+                            auto nm = detail::weekday_names();
+                            auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                            if (!is.fail())
+                                trial_wd = i % 7;
+#endif
+                        }
+                        else
+                            read(is, CharT{'%'}, width, modified, *fmt);
+                    }
+                    else  // *fmt == 'u' || *fmt == 'w'
+                    {
+#if !ONLY_C_LOCALE
+                        if (modified == CharT{})
+#else
+                        if (modified != CharT{'E'})
+#endif
+                        {
+                            read(is, ru{trial_wd, 1, width == -1 ?
+                                                      1u : static_cast<unsigned>(width)});
+                            if (!is.fail())
+                            {
+                                if (*fmt == 'u')
+                                {
+                                    if (!(1 <= trial_wd && trial_wd <= 7))
+                                    {
+                                        trial_wd = not_a_weekday;
+                                        is.setstate(ios::failbit);
+                                    }
+                                    else if (trial_wd == 7)
+                                        trial_wd = 0;
+                                }
+                                else  // *fmt == 'w'
+                                {
+                                    if (!(0 <= trial_wd && trial_wd <= 6))
+                                    {
+                                        trial_wd = not_a_weekday;
+                                        is.setstate(ios::failbit);
+                                    }
+                                }
+                            }
+                        }
+#if !ONLY_C_LOCALE
+                        else if (modified == CharT{'O'})
+                        {
+                            ios::iostate err = ios::goodbit;
+                            f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                            is.setstate(err);
+                            if (!is.fail())
+                                trial_wd = tm.tm_wday;
+                        }
+#endif
+                        else
+                            read(is, CharT{'%'}, width, modified, *fmt);
+                    }
+                    if (trial_wd != not_a_weekday)
+                        checked_set(wd, trial_wd, not_a_weekday, is);
+                }
+                else  // !command
+                    read(is, *fmt);
+                command = nullptr;
+                width = -1;
+                modified = CharT{};
+                break;
+            case 'b':
+            case 'B':
+            case 'h':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int ttm = not_a_month;
+#if !ONLY_C_LOCALE
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            ttm = tm.tm_mon + 1;
+                        is.setstate(err);
+#else
+                        auto nm = detail::month_names();
+                        auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                        if (!is.fail())
+                            ttm = i % 12 + 1;
+#endif
+                        checked_set(m, ttm, not_a_month, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'c':
+                if (command)
+                {
+                    if (modified != CharT{'O'})
+                    {
+#if !ONLY_C_LOCALE
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                        {
+                            checked_set(Y, tm.tm_year + 1900, not_a_year, is);
+                            checked_set(m, tm.tm_mon + 1, not_a_month, is);
+                            checked_set(d, tm.tm_mday, not_a_day, is);
+                            checked_set(H, tm.tm_hour, not_a_hour, is);
+                            checked_set(M, tm.tm_min, not_a_minute, is);
+                            checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
+                                        not_a_second, is);
+                        }
+                        is.setstate(err);
+#else
+                        // "%a %b %e %T %Y"
+                        auto nm = detail::weekday_names();
+                        auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                        checked_set(wd, static_cast<int>(i % 7), not_a_weekday, is);
+                        ws(is);
+                        nm = detail::month_names();
+                        i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                        checked_set(m, static_cast<int>(i % 12 + 1), not_a_month, is);
+                        ws(is);
+                        int td = not_a_day;
+                        read(is, rs{td, 1, 2});
+                        checked_set(d, td, not_a_day, is);
+                        ws(is);
+                        using dfs = detail::decimal_format_seconds<Duration>;
+                        CONSTDATA auto w = Duration::period::den == 1 ? 2 : 3 + dfs::width;
+                        int tH;
+                        int tM;
+                        long double S{};
+                        read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2},
+                                               CharT{':'}, rld{S, 1, w});
+                        checked_set(H, tH, not_a_hour, is);
+                        checked_set(M, tM, not_a_minute, is);
+                        checked_set(s, round_i<Duration>(duration<long double>{S}),
+                                    not_a_second, is);
+                        ws(is);
+                        int tY = not_a_year;
+                        read(is, rs{tY, 1, 4u});
+                        checked_set(Y, tY, not_a_year, is);
+#endif
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'x':
+                if (command)
+                {
+                    if (modified != CharT{'O'})
+                    {
+#if !ONLY_C_LOCALE
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                        {
+                            checked_set(Y, tm.tm_year + 1900, not_a_year, is);
+                            checked_set(m, tm.tm_mon + 1, not_a_month, is);
+                            checked_set(d, tm.tm_mday, not_a_day, is);
+                        }
+                        is.setstate(err);
+#else
+                        // "%m/%d/%y"
+                        int ty = not_a_2digit_year;
+                        int tm = not_a_month;
+                        int td = not_a_day;
+                        read(is, ru{tm, 1, 2}, CharT{'/'}, ru{td, 1, 2}, CharT{'/'},
+                                 rs{ty, 1, 2});
+                        checked_set(y, ty, not_a_2digit_year, is);
+                        checked_set(m, tm, not_a_month, is);
+                        checked_set(d, td, not_a_day, is);
+#endif
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'X':
+                if (command)
+                {
+                    if (modified != CharT{'O'})
+                    {
+#if !ONLY_C_LOCALE
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                        {
+                            checked_set(H, tm.tm_hour, not_a_hour, is);
+                            checked_set(M, tm.tm_min, not_a_minute, is);
+                            checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
+                                        not_a_second, is);
+                        }
+                        is.setstate(err);
+#else
+                        // "%T"
+                        using dfs = detail::decimal_format_seconds<Duration>;
+                        CONSTDATA auto w = Duration::period::den == 1 ? 2 : 3 + dfs::width;
+                        int tH = not_a_hour;
+                        int tM = not_a_minute;
+                        long double S{};
+                        read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2},
+                                               CharT{':'}, rld{S, 1, w});
+                        checked_set(H, tH, not_a_hour, is);
+                        checked_set(M, tM, not_a_minute, is);
+                        checked_set(s, round_i<Duration>(duration<long double>{S}),
+                                    not_a_second, is);
+#endif
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'C':
+                if (command)
+                {
+                    int tC = not_a_century;
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+                    {
+#endif
+                        read(is, rs{tC, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+#if !ONLY_C_LOCALE
+                    }
+                    else
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                        {
+                            auto tY = tm.tm_year + 1900;
+                            tC = (tY >= 0 ? tY : tY-99) / 100;
+                        }
+                        is.setstate(err);
+                    }
+#endif
+                    checked_set(C, tC, not_a_century, is);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'D':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tn = not_a_month;
+                        int td = not_a_day;
+                        int ty = not_a_2digit_year;
+                        read(is, ru{tn, 1, 2}, CharT{'\0'}, CharT{'/'}, CharT{'\0'},
+                                 ru{td, 1, 2}, CharT{'\0'}, CharT{'/'}, CharT{'\0'},
+                                 rs{ty, 1, 2});
+                        checked_set(y, ty, not_a_2digit_year, is);
+                        checked_set(m, tn, not_a_month, is);
+                        checked_set(d, td, not_a_day, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'F':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tY = not_a_year;
+                        int tn = not_a_month;
+                        int td = not_a_day;
+                        read(is, rs{tY, 1, width == -1 ? 4u : static_cast<unsigned>(width)},
+                                 CharT{'-'}, ru{tn, 1, 2}, CharT{'-'}, ru{td, 1, 2});
+                        checked_set(Y, tY, not_a_year, is);
+                        checked_set(m, tn, not_a_month, is);
+                        checked_set(d, td, not_a_day, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'd':
+            case 'e':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#else
+                    if (modified != CharT{'E'})
+#endif
+                    {
+                        int td = not_a_day;
+                        read(is, rs{td, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(d, td, not_a_day, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        command = nullptr;
+                        width = -1;
+                        modified = CharT{};
+                        if ((err & ios::failbit) == 0)
+                            checked_set(d, tm.tm_mday, not_a_day, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'H':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#else
+                    if (modified != CharT{'E'})
+#endif
+                    {
+                        int tH = not_a_hour;
+                        read(is, ru{tH, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(H, tH, not_a_hour, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(H, tm.tm_hour, not_a_hour, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'I':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tI = not_a_hour_12_value;
+                        // reads in an hour into I, but most be in [1, 12]
+                        read(is, rs{tI, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        if (!(1 <= tI && tI <= 12))
+                            is.setstate(ios::failbit);
+                        checked_set(I, tI, not_a_hour_12_value, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+               break;
+            case 'j':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tj = not_a_doy;
+                        read(is, ru{tj, 1, width == -1 ? 3u : static_cast<unsigned>(width)});
+                        checked_set(j, tj, not_a_doy, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'M':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#else
+                    if (modified != CharT{'E'})
+#endif
+                    {
+                        int tM = not_a_minute;
+                        read(is, ru{tM, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(M, tM, not_a_minute, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(M, tm.tm_min, not_a_minute, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'm':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#else
+                    if (modified != CharT{'E'})
+#endif
+                    {
+                        int tn = not_a_month;
+                        read(is, rs{tn, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(m, tn, not_a_month, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(m, tm.tm_mon + 1, not_a_month, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'n':
+            case 't':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        // %n matches a single white space character
+                        // %t matches 0 or 1 white space characters
+                        auto ic = is.peek();
+                        if (Traits::eq_int_type(ic, Traits::eof()))
+                        {
+                            ios::iostate err = ios::eofbit;
+                            if (*fmt == 'n')
+                                err |= ios::failbit;
+                            is.setstate(err);
+                            break;
+                        }
+                        if (isspace(ic))
+                        {
+                            (void)is.get();
+                        }
+                        else if (*fmt == 'n')
+                            is.setstate(ios::failbit);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'p':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tp = not_a_ampm;
+#if !ONLY_C_LOCALE
+                        tm = std::tm{};
+                        tm.tm_hour = 1;
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        is.setstate(err);
+                        if (tm.tm_hour == 1)
+                            tp = 0;
+                        else if (tm.tm_hour == 13)
+                            tp = 1;
+                        else
+                            is.setstate(err);
+#else
+                        auto nm = detail::ampm_names();
+                        auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                        tp = static_cast<decltype(tp)>(i);
+#endif
+                        checked_set(p, tp, not_a_ampm, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+
+               break;
+            case 'r':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+#if !ONLY_C_LOCALE
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                        {
+                            checked_set(H, tm.tm_hour, not_a_hour, is);
+                            checked_set(M, tm.tm_min, not_a_hour, is);
+                            checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
+                                        not_a_second, is);
+                        }
+                        is.setstate(err);
+#else
+                        // "%I:%M:%S %p"
+                        using dfs = detail::decimal_format_seconds<Duration>;
+                        CONSTDATA auto w = Duration::period::den == 1 ? 2 : 3 + dfs::width;
+                        long double S{};
+                        int tI = not_a_hour_12_value;
+                        int tM = not_a_minute;
+                        read(is, ru{tI, 1, 2}, CharT{':'}, ru{tM, 1, 2},
+                                               CharT{':'}, rld{S, 1, w});
+                        checked_set(I, tI, not_a_hour_12_value, is);
+                        checked_set(M, tM, not_a_minute, is);
+                        checked_set(s, round_i<Duration>(duration<long double>{S}),
+                                    not_a_second, is);
+                        ws(is);
+                        auto nm = detail::ampm_names();
+                        auto i = detail::scan_keyword(is, nm.first, nm.second) - nm.first;
+                        checked_set(p, static_cast<int>(i), not_a_ampm, is);
+#endif
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'R':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tH = not_a_hour;
+                        int tM = not_a_minute;
+                        read(is, ru{tH, 1, 2}, CharT{'\0'}, CharT{':'}, CharT{'\0'},
+                                 ru{tM, 1, 2}, CharT{'\0'});
+                        checked_set(H, tH, not_a_hour, is);
+                        checked_set(M, tM, not_a_minute, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'S':
+                if (command)
+                {
+ #if !ONLY_C_LOCALE
+                   if (modified == CharT{})
+#else
+                   if (modified != CharT{'E'})
+#endif
+                    {
+                        using dfs = detail::decimal_format_seconds<Duration>;
+                        CONSTDATA auto w = Duration::period::den == 1 ? 2 : 3 + dfs::width;
+                        long double S{};
+                        read(is, rld{S, 1, width == -1 ? w : static_cast<unsigned>(width)});
+                        checked_set(s, round_i<Duration>(duration<long double>{S}),
+                                    not_a_second, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'O'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(s, duration_cast<Duration>(seconds{tm.tm_sec}),
+                                        not_a_second, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'T':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        using dfs = detail::decimal_format_seconds<Duration>;
+                        CONSTDATA auto w = Duration::period::den == 1 ? 2 : 3 + dfs::width;
+                        int tH = not_a_hour;
+                        int tM = not_a_minute;
+                        long double S{};
+                        read(is, ru{tH, 1, 2}, CharT{':'}, ru{tM, 1, 2},
+                                               CharT{':'}, rld{S, 1, w});
+                        checked_set(H, tH, not_a_hour, is);
+                        checked_set(M, tM, not_a_minute, is);
+                        checked_set(s, round_i<Duration>(duration<long double>{S}),
+                                    not_a_second, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'Y':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#else
+                    if (modified != CharT{'O'})
+#endif
+                    {
+                        int tY = not_a_year;
+                        read(is, rs{tY, 1, width == -1 ? 4u : static_cast<unsigned>(width)});
+                        checked_set(Y, tY, not_a_year, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else if (modified == CharT{'E'})
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(Y, tm.tm_year + 1900, not_a_year, is);
+                        is.setstate(err);
+                    }
+#endif
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'y':
+                if (command)
+                {
+#if !ONLY_C_LOCALE
+                    if (modified == CharT{})
+#endif
+                    {
+                        int ty = not_a_2digit_year;
+                        read(is, ru{ty, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(y, ty, not_a_2digit_year, is);
+                    }
+#if !ONLY_C_LOCALE
+                    else
+                    {
+                        ios::iostate err = ios::goodbit;
+                        f.get(is, nullptr, is, err, &tm, command, fmt+1);
+                        if ((err & ios::failbit) == 0)
+                            checked_set(Y, tm.tm_year + 1900, not_a_year, is);
+                        is.setstate(err);
+                    }
+#endif
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'g':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tg = not_a_2digit_year;
+                        read(is, ru{tg, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(g, tg, not_a_2digit_year, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'G':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tG = not_a_year;
+                        read(is, rs{tG, 1, width == -1 ? 4u : static_cast<unsigned>(width)});
+                        checked_set(G, tG, not_a_year, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'U':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tU = not_a_week_num;
+                        read(is, ru{tU, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(U, tU, not_a_week_num, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'V':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tV = not_a_week_num;
+                        read(is, ru{tV, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(V, tV, not_a_week_num, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'W':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        int tW = not_a_week_num;
+                        read(is, ru{tW, 1, width == -1 ? 2u : static_cast<unsigned>(width)});
+                        checked_set(W, tW, not_a_week_num, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'E':
+            case 'O':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        modified = *fmt;
+                    }
+                    else
+                    {
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                        command = nullptr;
+                        width = -1;
+                        modified = CharT{};
+                    }
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case '%':
+                if (command)
+                {
+                    if (modified == CharT{})
+                        read(is, *fmt);
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    command = fmt;
+                break;
+            case 'z':
+                if (command)
+                {
+                    int tH, tM;
+                    minutes toff = not_a_offset;
+                    bool neg = false;
+                    auto ic = is.peek();
+                    if (!Traits::eq_int_type(ic, Traits::eof()))
+                    {
+                        auto c = static_cast<char>(Traits::to_char_type(ic));
+                        if (c == '-')
+                        {
+                            neg = true;
+                            (void)is.get();
+                        }
+                        else if (c == '+')
+                            (void)is.get();
+                    }
+                    if (modified == CharT{})
+                    {
+                        read(is, rs{tH, 2, 2});
+                        if (!is.fail())
+                            toff = hours{std::abs(tH)};
+                        if (is.good())
+                        {
+                            ic = is.peek();
+                            if (!Traits::eq_int_type(ic, Traits::eof()))
+                            {
+                                auto c = static_cast<char>(Traits::to_char_type(ic));
+                                if ('0' <= c && c <= '9')
+                                {
+                                    read(is, ru{tM, 2, 2});
+                                    if (!is.fail())
+                                        toff += minutes{tM};
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        read(is, rs{tH, 1, 2});
+                        if (!is.fail())
+                            toff = hours{std::abs(tH)};
+                        if (is.good())
+                        {
+                            ic = is.peek();
+                            if (!Traits::eq_int_type(ic, Traits::eof()))
+                            {
+                                auto c = static_cast<char>(Traits::to_char_type(ic));
+                                if (c == ':')
+                                {
+                                    (void)is.get();
+                                    read(is, ru{tM, 2, 2});
+                                    if (!is.fail())
+                                        toff += minutes{tM};
+                                }
+                            }
+                        }
+                    }
+                    if (neg)
+                        toff = -toff;
+                    checked_set(temp_offset, toff, not_a_offset, is);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            case 'Z':
+                if (command)
+                {
+                    if (modified == CharT{})
+                    {
+                        std::basic_string<CharT, Traits, Alloc> buf;
+                        while (is.rdstate() == std::ios::goodbit)
+                        {
+                            auto i = is.rdbuf()->sgetc();
+                            if (Traits::eq_int_type(i, Traits::eof()))
+                            {
+                                is.setstate(ios::eofbit);
+                                break;
+                            }
+                            auto wc = Traits::to_char_type(i);
+                            auto c = static_cast<char>(wc);
+                            // is c a valid time zone name or abbreviation character?
+                            if (!(CharT{1} < wc && wc < CharT{127}) || !(isalnum(c) ||
+                                    c == '_' || c == '/' || c == '-' || c == '+'))
+                                break;
+                            buf.push_back(c);
+                            is.rdbuf()->sbumpc();
+                        }
+                        if (buf.empty())
+                            is.setstate(ios::failbit);
+                        checked_set(temp_abbrev, buf, {}, is);
+                    }
+                    else
+                        read(is, CharT{'%'}, width, modified, *fmt);
+                    command = nullptr;
+                    width = -1;
+                    modified = CharT{};
+                }
+                else
+                    read(is, *fmt);
+                break;
+            default:
+                if (command)
+                {
+                    if (width == -1 && modified == CharT{} && '0' <= *fmt && *fmt <= '9')
+                    {
+                        width = static_cast<char>(*fmt) - '0';
+                        while ('0' <= fmt[1] && fmt[1] <= '9')
+                            width = 10*width + static_cast<char>(*++fmt) - '0';
+                    }
+                    else
+                    {
+                        if (modified == CharT{})
+                            read(is, CharT{'%'}, width, *fmt);
+                        else
+                            read(is, CharT{'%'}, width, modified, *fmt);
+                        command = nullptr;
+                        width = -1;
+                        modified = CharT{};
+                    }
+                }
+                else  // !command
+                {
+                    if (isspace(static_cast<unsigned char>(*fmt)))
+                    {
+                        // space matches 0 or more white space characters
+                        if (is.good())
+                           ws(is);
+                    }
+                    else
+                        read(is, *fmt);
+                }
+                break;
             }
-          } else  // I is ambiguous, AM or PM?
-            goto broken;
         }
-      }
-      if (H != not_a_hour) {
-        fds.has_tod = true;
-        fds.tod = hh_mm_ss<Duration>{hours{H}};
-      }
-      if (M != not_a_minute) {
-        fds.has_tod = true;
-        fds.tod.m_ = minutes{M};
-      }
-      if (s != not_a_second) {
-        fds.has_tod = true;
-        fds.tod.s_ = detail::decimal_format_seconds<Duration>{s};
-      }
-      if (j != not_a_doy) {
-        fds.has_tod = true;
-        fds.tod.h_ += hours{days{j}};
-      }
-      if (wd != not_a_weekday) fds.wd = weekday{static_cast<unsigned>(wd)};
-      if (abbrev != nullptr) *abbrev = std::move(temp_abbrev);
-      if (offset != nullptr && temp_offset != not_a_offset)
-        *offset = temp_offset;
+        // is.fail() || *fmt == CharT{}
+        if (is.rdstate() == ios::goodbit && command)
+        {
+            if (modified == CharT{})
+                read(is, CharT{'%'}, width);
+            else
+                read(is, CharT{'%'}, width, modified);
+        }
+        if (!is.fail())
+        {
+            if (y != not_a_2digit_year)
+            {
+                // Convert y and an optional C to Y
+                if (!(0 <= y && y <= 99))
+                    goto broken;
+                if (C == not_a_century)
+                {
+                    if (Y == not_a_year)
+                    {
+                        if (y >= 69)
+                            C = 19;
+                        else
+                            C = 20;
+                    }
+                    else
+                    {
+                        C = (Y >= 0 ? Y : Y-100) / 100;
+                    }
+                }
+                int tY;
+                if (C >= 0)
+                    tY = 100*C + y;
+                else
+                    tY = 100*(C+1) - (y == 0 ? 100 : y);
+                if (Y != not_a_year && Y != tY)
+                    goto broken;
+                Y = tY;
+            }
+            if (g != not_a_2digit_year)
+            {
+                // Convert g and an optional C to G
+                if (!(0 <= g && g <= 99))
+                    goto broken;
+                if (C == not_a_century)
+                {
+                    if (G == not_a_year)
+                    {
+                        if (g >= 69)
+                            C = 19;
+                        else
+                            C = 20;
+                    }
+                    else
+                    {
+                        C = (G >= 0 ? G : G-100) / 100;
+                    }
+                }
+                int tG;
+                if (C >= 0)
+                    tG = 100*C + g;
+                else
+                    tG = 100*(C+1) - (g == 0 ? 100 : g);
+                if (G != not_a_year && G != tG)
+                    goto broken;
+                G = tG;
+            }
+            if (Y < static_cast<int>(year::min()) || Y > static_cast<int>(year::max()))
+                Y = not_a_year;
+            bool computed = false;
+            if (G != not_a_year && V != not_a_week_num && wd != not_a_weekday)
+            {
+                year_month_day ymd_trial = sys_days(year{G-1}/December/Thursday[last]) +
+                                           (Monday-Thursday) + weeks{V-1} +
+                                           (weekday{static_cast<unsigned>(wd)}-Monday);
+                if (Y == not_a_year)
+                    Y = static_cast<int>(ymd_trial.year());
+                else if (year{Y} != ymd_trial.year())
+                    goto broken;
+                if (m == not_a_month)
+                    m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
+                else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
+                    goto broken;
+                if (d == not_a_day)
+                    d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
+                else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
+                    goto broken;
+                computed = true;
+            }
+            if (Y != not_a_year && U != not_a_week_num && wd != not_a_weekday)
+            {
+                year_month_day ymd_trial = sys_days(year{Y}/January/Sunday[1]) +
+                                           weeks{U-1} +
+                                           (weekday{static_cast<unsigned>(wd)} - Sunday);
+                if (Y == not_a_year)
+                    Y = static_cast<int>(ymd_trial.year());
+                else if (year{Y} != ymd_trial.year())
+                    goto broken;
+                if (m == not_a_month)
+                    m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
+                else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
+                    goto broken;
+                if (d == not_a_day)
+                    d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
+                else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
+                    goto broken;
+                computed = true;
+            }
+            if (Y != not_a_year && W != not_a_week_num && wd != not_a_weekday)
+            {
+                year_month_day ymd_trial = sys_days(year{Y}/January/Monday[1]) +
+                                           weeks{W-1} +
+                                           (weekday{static_cast<unsigned>(wd)} - Monday);
+                if (Y == not_a_year)
+                    Y = static_cast<int>(ymd_trial.year());
+                else if (year{Y} != ymd_trial.year())
+                    goto broken;
+                if (m == not_a_month)
+                    m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
+                else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
+                    goto broken;
+                if (d == not_a_day)
+                    d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
+                else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
+                    goto broken;
+                computed = true;
+            }
+            if (j != not_a_doy && Y != not_a_year)
+            {
+                auto ymd_trial = year_month_day{local_days(year{Y}/1/1) + days{j-1}};
+                if (m == not_a_month)
+                    m = static_cast<int>(static_cast<unsigned>(ymd_trial.month()));
+                else if (month(static_cast<unsigned>(m)) != ymd_trial.month())
+                    goto broken;
+                if (d == not_a_day)
+                    d = static_cast<int>(static_cast<unsigned>(ymd_trial.day()));
+                else if (day(static_cast<unsigned>(d)) != ymd_trial.day())
+                    goto broken;
+                j = not_a_doy;
+            }
+            auto ymd = year{Y}/m/d;
+            if (ymd.ok())
+            {
+                if (wd == not_a_weekday)
+                    wd = static_cast<int>((weekday(sys_days(ymd)) - Sunday).count());
+                else if (wd != static_cast<int>((weekday(sys_days(ymd)) - Sunday).count()))
+                    goto broken;
+                if (!computed)
+                {
+                    if (G != not_a_year || V != not_a_week_num)
+                    {
+                        sys_days sd = ymd;
+                        auto G_trial = year_month_day{sd + days{3}}.year();
+                        auto start = sys_days((G_trial - years{1})/December/Thursday[last]) +
+                                     (Monday - Thursday);
+                        if (sd < start)
+                        {
+                            --G_trial;
+                            if (V != not_a_week_num)
+                                start = sys_days((G_trial - years{1})/December/Thursday[last])
+                                        + (Monday - Thursday);
+                        }
+                        if (G != not_a_year && G != static_cast<int>(G_trial))
+                            goto broken;
+                        if (V != not_a_week_num)
+                        {
+                            auto V_trial = duration_cast<weeks>(sd - start).count() + 1;
+                            if (V != V_trial)
+                                goto broken;
+                        }
+                    }
+                    if (U != not_a_week_num)
+                    {
+                        auto start = sys_days(Sunday[1]/January/ymd.year());
+                        auto U_trial = floor<weeks>(sys_days(ymd) - start).count() + 1;
+                        if (U != U_trial)
+                            goto broken;
+                    }
+                    if (W != not_a_week_num)
+                    {
+                        auto start = sys_days(Monday[1]/January/ymd.year());
+                        auto W_trial = floor<weeks>(sys_days(ymd) - start).count() + 1;
+                        if (W != W_trial)
+                            goto broken;
+                    }
+                }
+            }
+            fds.ymd = ymd;
+            if (I != not_a_hour_12_value)
+            {
+                if (!(1 <= I && I <= 12))
+                    goto broken;
+                if (p != not_a_ampm)
+                {
+                    // p is in [0, 1] == [AM, PM]
+                    // Store trial H in I
+                    if (I == 12)
+                        --p;
+                    I += p*12;
+                    // Either set H from I or make sure H and I are consistent
+                    if (H == not_a_hour)
+                        H = I;
+                    else if (I != H)
+                        goto broken;
+                }
+                else  // p == not_a_ampm
+                {
+                    // if H, make sure H and I could be consistent
+                    if (H != not_a_hour)
+                    {
+                        if (I == 12)
+                        {
+                            if (H != 0 && H != 12)
+                                goto broken;
+                        }
+                        else if (!(I == H || I == H+12))
+                        {
+                            goto broken;
+                        }
+                    }
+                    else  // I is ambiguous, AM or PM?
+                        goto broken;
+                }
+            }
+            if (H != not_a_hour)
+            {
+                fds.has_tod = true;
+                fds.tod = hh_mm_ss<Duration>{hours{H}};
+            }
+            if (M != not_a_minute)
+            {
+                fds.has_tod = true;
+                fds.tod.m_ = minutes{M};
+            }
+            if (s != not_a_second)
+            {
+                fds.has_tod = true;
+                fds.tod.s_ = detail::decimal_format_seconds<Duration>{s};
+            }
+            if (j != not_a_doy)
+            {
+                fds.has_tod = true;
+                fds.tod.h_ += hours{days{j}};
+            }
+            if (wd != not_a_weekday)
+                fds.wd = weekday{static_cast<unsigned>(wd)};
+            if (abbrev != nullptr)
+                *abbrev = std::move(temp_abbrev);
+            if (offset != nullptr && temp_offset != not_a_offset)
+              *offset = temp_offset;
+        }
+       return is;
     }
-    return is;
-  }
 broken:
-  is.setstate(ios::failbit);
-  return is;
+    is.setstate(ios::failbit);
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, year& y,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.year().ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) y = fds.ymd.year();
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, year& y,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.year().ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        y = fds.ymd.year();
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, month& m,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.month().ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) m = fds.ymd.month();
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, month& m,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.month().ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        m = fds.ymd.month();
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, day& d,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.day().ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) d = fds.ymd.day();
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, day& d,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.day().ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        d = fds.ymd.day();
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, weekday& wd,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.wd.ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) wd = fds.wd;
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, weekday& wd,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.wd.ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        wd = fds.wd;
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, year_month& ym,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.month().ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) ym = fds.ymd.year() / fds.ymd.month();
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, year_month& ym,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.month().ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        ym = fds.ymd.year()/fds.ymd.month();
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt, month_day& md,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.month().ok() || !fds.ymd.day().ok())
-    is.setstate(std::ios::failbit);
-  if (!is.fail()) md = fds.ymd.month() / fds.ymd.day();
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt, month_day& md,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.month().ok() || !fds.ymd.day().ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        md = fds.ymd.month()/fds.ymd.day();
+    return is;
 }
 
 template <class CharT, class Traits, class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    year_month_day& ymd,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = std::chrono::seconds;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.ok()) is.setstate(std::ios::failbit);
-  if (!is.fail()) ymd = fds.ymd;
-  return is;
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            year_month_day& ymd, std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = std::chrono::seconds;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.ok())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        ymd = fds.ymd;
+    return is;
 }
 
-template <class Duration, class CharT, class Traits,
-          class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    sys_time<Duration>& tp,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  using detail::round_i;
-  std::chrono::minutes offset_local{};
-  auto offptr = offset ? offset : &offset_local;
-  fields<CT> fds{};
-  fds.has_tod = true;
-  date::from_stream(is, fmt, fds, abbrev, offptr);
-  if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
-    is.setstate(std::ios::failbit);
-  if (!is.fail())
-    tp = round_i<Duration>(sys_days(fds.ymd) - *offptr + fds.tod.to_duration());
-  return is;
+template <class Duration, class CharT, class Traits, class Alloc = std::allocator<CharT>>
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            sys_time<Duration>& tp, std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    using detail::round_i;
+    std::chrono::minutes offset_local{};
+    auto offptr = offset ? offset : &offset_local;
+    fields<CT> fds{};
+    fds.has_tod = true;
+    date::from_stream(is, fmt, fds, abbrev, offptr);
+    if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        tp = round_i<Duration>(sys_days(fds.ymd) - *offptr + fds.tod.to_duration());
+    return is;
 }
 
-template <class Duration, class CharT, class Traits,
-          class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    local_time<Duration>& tp,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  using detail::round_i;
-  fields<CT> fds{};
-  fds.has_tod = true;
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
-    is.setstate(std::ios::failbit);
-  if (!is.fail())
-    tp = round_i<Duration>(local_seconds{local_days(fds.ymd)} +
-                           fds.tod.to_duration());
-  return is;
+template <class Duration, class CharT, class Traits, class Alloc = std::allocator<CharT>>
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            local_time<Duration>& tp, std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    using detail::round_i;
+    fields<CT> fds{};
+    fds.has_tod = true;
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.ymd.ok() || !fds.tod.in_conventional_range())
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        tp = round_i<Duration>(local_seconds{local_days(fds.ymd)} + fds.tod.to_duration());
+    return is;
 }
 
-template <class Rep, class Period, class CharT, class Traits,
-          class Alloc = std::allocator<CharT>>
-std::basic_istream<CharT, Traits>& from_stream(
-    std::basic_istream<CharT, Traits>& is, const CharT* fmt,
-    std::chrono::duration<Rep, Period>& d,
-    std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-    std::chrono::minutes* offset = nullptr) {
-  using Duration = std::chrono::duration<Rep, Period>;
-  using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
-  using detail::round_i;
-  fields<CT> fds{};
-  date::from_stream(is, fmt, fds, abbrev, offset);
-  if (!fds.has_tod) is.setstate(std::ios::failbit);
-  if (!is.fail()) d = round_i<Duration>(fds.tod.to_duration());
-  return is;
+template <class Rep, class Period, class CharT, class Traits, class Alloc = std::allocator<CharT>>
+std::basic_istream<CharT, Traits>&
+from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
+            std::chrono::duration<Rep, Period>& d,
+            std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+            std::chrono::minutes* offset = nullptr)
+{
+    using Duration = std::chrono::duration<Rep, Period>;
+    using CT = typename std::common_type<Duration, std::chrono::seconds>::type;
+    using detail::round_i;
+    fields<CT> fds{};
+    date::from_stream(is, fmt, fds, abbrev, offset);
+    if (!fds.has_tod)
+        is.setstate(std::ios::failbit);
+    if (!is.fail())
+        d = round_i<Duration>(fds.tod.to_duration());
+    return is;
 }
 
 template <class Parsable, class CharT, class Traits = std::char_traits<CharT>,
           class Alloc = std::allocator<CharT>>
-struct parse_manip {
-  const std::basic_string<CharT, Traits, Alloc> format_;
-  Parsable& tp_;
-  std::basic_string<CharT, Traits, Alloc>* abbrev_;
-  std::chrono::minutes* offset_;
+struct parse_manip
+{
+    const std::basic_string<CharT, Traits, Alloc> format_;
+    Parsable&                                     tp_;
+    std::basic_string<CharT, Traits, Alloc>*      abbrev_;
+    std::chrono::minutes*                         offset_;
 
- public:
-  parse_manip(std::basic_string<CharT, Traits, Alloc> format, Parsable& tp,
-              std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-              std::chrono::minutes* offset = nullptr)
-      : format_(std::move(format)), tp_(tp), abbrev_(abbrev), offset_(offset) {}
+public:
+    parse_manip(std::basic_string<CharT, Traits, Alloc> format, Parsable& tp,
+                std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+                std::chrono::minutes* offset = nullptr)
+        : format_(std::move(format))
+        , tp_(tp)
+        , abbrev_(abbrev)
+        , offset_(offset)
+        {}
 
 #if HAS_STRING_VIEW
-  parse_manip(const CharT* format, Parsable& tp,
-              std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-              std::chrono::minutes* offset = nullptr)
-      : format_(format), tp_(tp), abbrev_(abbrev), offset_(offset) {}
+    parse_manip(const CharT* format, Parsable& tp,
+                std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+                std::chrono::minutes* offset = nullptr)
+        : format_(format)
+        , tp_(tp)
+        , abbrev_(abbrev)
+        , offset_(offset)
+        {}
 
-  parse_manip(std::basic_string_view<CharT, Traits> format, Parsable& tp,
-              std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
-              std::chrono::minutes* offset = nullptr)
-      : format_(format), tp_(tp), abbrev_(abbrev), offset_(offset) {}
+    parse_manip(std::basic_string_view<CharT, Traits> format, Parsable& tp,
+                std::basic_string<CharT, Traits, Alloc>* abbrev = nullptr,
+                std::chrono::minutes* offset = nullptr)
+        : format_(format)
+        , tp_(tp)
+        , abbrev_(abbrev)
+        , offset_(offset)
+        {}
 #endif  // HAS_STRING_VIEW
 };
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-std::basic_istream<CharT, Traits>& operator>>(
-    std::basic_istream<CharT, Traits>& is,
-    const parse_manip<Parsable, CharT, Traits, Alloc>& x) {
-  return date::from_stream(is, x.format_.c_str(), x.tp_, x.abbrev_, x.offset_);
+std::basic_istream<CharT, Traits>&
+operator>>(std::basic_istream<CharT, Traits>& is,
+           const parse_manip<Parsable, CharT, Traits, Alloc>& x)
+{
+    return date::from_stream(is, x.format_.c_str(), x.tp_, x.abbrev_, x.offset_);
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const std::basic_string<CharT, Traits, Alloc>& format,
-                  Parsable& tp)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(),
-                    format.c_str(), tp),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp}) {
-  return {format, tp};
+inline
+auto
+parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                            format.c_str(), tp),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp})
+{
+    return {format, tp};
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const std::basic_string<CharT, Traits, Alloc>& format,
-                  Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(),
-                    format.c_str(), tp, &abbrev),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp,
-                                                            &abbrev}) {
-  return {format, tp, &abbrev};
+inline
+auto
+parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+      std::basic_string<CharT, Traits, Alloc>& abbrev)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                            format.c_str(), tp, &abbrev),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
+{
+    return {format, tp, &abbrev};
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const std::basic_string<CharT, Traits, Alloc>& format,
-                  Parsable& tp, std::chrono::minutes& offset)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(),
-                    format.c_str(), tp,
-                    std::declval<std::basic_string<CharT, Traits, Alloc>*>(),
-                    &offset),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, nullptr,
-                                                            &offset}) {
-  return {format, tp, nullptr, &offset};
+inline
+auto
+parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+      std::chrono::minutes& offset)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                            format.c_str(), tp,
+                            std::declval<std::basic_string<CharT, Traits, Alloc>*>(),
+                            &offset),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, nullptr, &offset})
+{
+    return {format, tp, nullptr, &offset};
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const std::basic_string<CharT, Traits, Alloc>& format,
-                  Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev,
-                  std::chrono::minutes& offset)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(),
-                    format.c_str(), tp, &abbrev, &offset),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev,
-                                                            &offset}) {
-  return {format, tp, &abbrev, &offset};
+inline
+auto
+parse(const std::basic_string<CharT, Traits, Alloc>& format, Parsable& tp,
+      std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(),
+                            format.c_str(), tp, &abbrev, &offset),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
+{
+    return {format, tp, &abbrev, &offset};
 }
 
 // const CharT* formats
 
 template <class Parsable, class CharT>
-inline auto parse(const CharT* format, Parsable& tp)
-    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(),
-                                  format, tp),
-                parse_manip<Parsable, CharT>{format, tp}) {
-  return {format, tp};
+inline
+auto
+parse(const CharT* format, Parsable& tp)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(), format, tp),
+                parse_manip<Parsable, CharT>{format, tp})
+{
+    return {format, tp};
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const CharT* format, Parsable& tp,
-                  std::basic_string<CharT, Traits, Alloc>& abbrev)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(), format,
-                    tp, &abbrev),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp,
-                                                            &abbrev}) {
-  return {format, tp, &abbrev};
+inline
+auto
+parse(const CharT* format, Parsable& tp, std::basic_string<CharT, Traits, Alloc>& abbrev)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
+                            tp, &abbrev),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev})
+{
+    return {format, tp, &abbrev};
 }
 
 template <class Parsable, class CharT>
-inline auto parse(const CharT* format, Parsable& tp,
-                  std::chrono::minutes& offset)
-    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(),
-                                  format, tp,
-                                  std::declval<std::basic_string<CharT>*>(),
-                                  &offset),
-                parse_manip<Parsable, CharT>{format, tp, nullptr, &offset}) {
-  return {format, tp, nullptr, &offset};
+inline
+auto
+parse(const CharT* format, Parsable& tp, std::chrono::minutes& offset)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT>&>(), format,
+                            tp, std::declval<std::basic_string<CharT>*>(), &offset),
+                parse_manip<Parsable, CharT>{format, tp, nullptr, &offset})
+{
+    return {format, tp, nullptr, &offset};
 }
 
 template <class Parsable, class CharT, class Traits, class Alloc>
-inline auto parse(const CharT* format, Parsable& tp,
-                  std::basic_string<CharT, Traits, Alloc>& abbrev,
-                  std::chrono::minutes& offset)
-    -> decltype(date::from_stream(
-                    std::declval<std::basic_istream<CharT, Traits>&>(), format,
-                    tp, &abbrev, &offset),
-                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev,
-                                                            &offset}) {
-  return {format, tp, &abbrev, &offset};
+inline
+auto
+parse(const CharT* format, Parsable& tp,
+      std::basic_string<CharT, Traits, Alloc>& abbrev, std::chrono::minutes& offset)
+    -> decltype(date::from_stream(std::declval<std::basic_istream<CharT, Traits>&>(), format,
+                            tp, &abbrev, &offset),
+                parse_manip<Parsable, CharT, Traits, Alloc>{format, tp, &abbrev, &offset})
+{
+    return {format, tp, &abbrev, &offset};
 }
 
 // duration streaming
 
 template <class CharT, class Traits, class Rep, class Period>
-inline std::basic_ostream<CharT, Traits>& operator<<(
-    std::basic_ostream<CharT, Traits>& os,
-    const std::chrono::duration<Rep, Period>& d) {
-  return os << detail::make_string<CharT, Traits>::from(d.count()) +
-                   detail::get_units<CharT>(typename Period::type{});
+inline
+std::basic_ostream<CharT, Traits>&
+operator<<(std::basic_ostream<CharT, Traits>& os,
+           const std::chrono::duration<Rep, Period>& d)
+{
+    return os << detail::make_string<CharT, Traits>::from(d.count()) +
+                 detail::get_units<CharT>(typename Period::type{});
 }
 
 }  // namespace date
 
 #ifdef _MSC_VER
-#pragma warning(pop)
+#   pragma warning(pop)
 #endif
 
 #ifdef __GNUC__
-#pragma GCC diagnostic pop
+# pragma GCC diagnostic pop
 #endif
 
 #endif  // DATE_H


### PR DESCRIPTION
# Modernizing code 
1. Adding trailing return types, `[[nodiscard]]` throughout
2. Reducing cognitive complexity in some sections
3. Setting appropriate minimum versions and testing against various GCC/SWIG versions
4. Making code properly installable
5. Disabling additional install data when building for pip
6. Updating the header-only date library